### PR TITLE
docs: Move to sphinx-autoissues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,25 +4,28 @@
 
 - _Add your latest changes from PRs here_
 
+### Documentation
+
+- Render changelog with sphinx-autoissues, #360
+
 ### Development
 
 Infrastructure updates for static type checking and doctest examples.
 
-- Initial [doctests] support added, via #359 
+- Initial [doctests] support added, via #359
 
   [doctests]: https://docs.python.org/3/library/doctest.html
 
-- Initial [mypy] validation, via #359 
+- Initial [mypy] validation, via #359
 
   [mypy]: https://github.com/python/mypy
 
-- CI (tests, docs): Improve caching of python dependencies via
-  `action/setup-python`'s v3/4's new poetry caching, via #359
+- CI (tests, docs): Improve caching of python dependencies via `action/setup-python`'s v3/4's new
+  poetry caching, via #359
 
 - CI (docs): Skip if no `PUBLISH` condition triggered, via #359
 
-- CI: Remove `.pre-commit-config.yaml`, users should know enough to handle these
-  things themselves.
+- CI: Remove `.pre-commit-config.yaml`, users should know enough to handle these things themselves.
 
 ## django-slugify-processor 1.1.1 (2022-03-08)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
+    "sphinx_autoissues",
     "myst_parser",
 ]
 myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
@@ -79,6 +80,10 @@ html_sidebars = {
         "sidebar/scroll-end.html",
     ]
 }
+
+# sphinx-autoissues
+issuetracker = "github"
+issuetracker_project = "tony/django-slugify-processor"
 
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -783,22 +783,6 @@ doc = ["furo", "myst-parser"]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "sphinx-issues"
-version = "3.0.1"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "pytest (>=6.2.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
-tests = ["pytest (>=6.2.0)"]
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -993,7 +977,7 @@ test = ["django-extensions"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2679b25b040a4dbd40ff718654c819eb0b38279d7632ceeee445449c2e8103f5"
+content-hash = "cfd2d93126a696f073e760de89e96a0bd418d271d6ef1638ad54cae526b22a3f"
 
 [metadata.files]
 alabaster = [
@@ -1398,10 +1382,6 @@ sphinx-copybutton = [
 sphinx-inline-tabs = [
     {file = "sphinx_inline_tabs-2021.4.11b8-py3-none-any.whl", hash = "sha256:efd6e7ad576a6bc1c616cbaa9b0e6f6fe2b28a776947069ed8d6037667799808"},
     {file = "sphinx_inline_tabs-2021.4.11b8.tar.gz", hash = "sha256:3c4d7759cbbb7752b7e7acd96ed0ea2c58fcc4ae38891a718544b931a5a4818f"},
-]
-sphinx-issues = [
-    {file = "sphinx-issues-3.0.1.tar.gz", hash = "sha256:b7c1dc1f4808563c454d11c1112796f8c176cdecfee95f0fd2302ef98e21e3d6"},
-    {file = "sphinx_issues-3.0.1-py3-none-any.whl", hash = "sha256:8b25dc0301159375468f563b3699af7a63720fd84caf81c1442036fcd418b20c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -731,6 +731,14 @@ testing = ["covdefaults (>=2)", "coverage (>=6)", "diff-cover (>=6.4)", "nptypin
 type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
+name = "sphinx-autoissues"
+version = "0.0.1"
+description = "Sphinx integration with different issuetrackers"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -985,7 +993,7 @@ test = ["django-extensions"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f7e58220931951c720630c8412e3751c874a81ae54fb67eb7f50f48224eb7d1a"
+content-hash = "2679b25b040a4dbd40ff718654c819eb0b38279d7632ceeee445449c2e8103f5"
 
 [metadata.files]
 alabaster = [
@@ -1374,6 +1382,10 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.17.1-py3-none-any.whl", hash = "sha256:f16491cad05a13f4825ecdf9ee4ff02925d9a3b1cf103d4d02f2f81802cce653"},
     {file = "sphinx_autodoc_typehints-1.17.1.tar.gz", hash = "sha256:844d7237d3f6280b0416f5375d9556cfd84df1945356fcc34b82e8aaacab40f3"},
+]
+sphinx-autoissues = [
+    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
+    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ sphinx = "*"
 furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
-sphinx-issues = "*"
 sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
@@ -91,7 +90,6 @@ django-stubs = "^1.12.0"
 [tool.poetry.extras]
 docs = [
   "sphinx",
-  "sphinx-issues",
   "sphinx-autodoc-typehints",
   "sphinx-autobuild",
   "sphinx-copybutton",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
+sphinx-autoissues = "*"
 myst_parser = "*"
 
 ### Testing ###
@@ -97,6 +98,7 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
+  "sphinx-autoissues",
   "myst_parser",
   "furo",
 ]


### PR DESCRIPTION
https://github.com/tony/sphinx-autoissues ([Homepage](https://sphinx-autoissues.git-pull.com/))

This is a fork of [sphinxcontrib-issuetracker](https://github.com/lunaryorn/sphinxcontrib-issuetracker) but heavily modified. In the end the similarities between the packages may be less: But the major point is we want plain text issues to be linked