### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from django_slugify_processor import __about__, text, templatetags, __version__
+          from django_slugify_processor.templatetags import slugify_processor
+          print("django_slugify_processor version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Adds a CI check to verify runtime dependencies and documents the improvement.

CI:
- Adds a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.
- The check prints the package version and runs a basic functionality test.

Chores:
- Documents the improvement in the `CHANGES` file.