### PR TITLE
ci(release): Migrate to PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      id-token: write
+      attestations: write
 
     strategy:
       matrix:
@@ -80,6 +83,5 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          attestations: true
+          skip-existing: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ def test_custom_processor(settings):
 
 ### Imports
 
-- Prefer namespace imports (e.g., `import typing as t`), avoiding `from module import *`
+- Prefer namespace imports for stdlib (e.g., `import typing as t`); third-party packages may use `from X import Y`
 - Include `from __future__ import annotations` at the top of Python files
 
 ### Docstrings

--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,10 @@ $ uvx --from 'django-slugify-processor' --prerelease allow django-slugify-proces
 - _Add your latest changes from PRs here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### CI
+
+- Migrate to PyPI Trusted Publisher (#410)
+
 ### Documentation
 
 - Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#417)


### PR DESCRIPTION
## Summary
- Migrate PyPI publishing from API token to OIDC-based Trusted Publisher
- Enable package attestations for supply chain security
- Fix deprecated `skip_existing` parameter

## Setup Required
Before merging, configure the trusted publisher on PyPI:
1. Visit: https://pypi.org/manage/project/django-slugify-processor/settings/publishing/
2. Add publisher with:
   - Owner: `tony`
   - Repository: `django-slugify-processor`
   - Workflow: `tests.yml`