### PR TITLE
docs(feat[api-style]): Visual improvements to API docs via gp-sphinx

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,11 @@ $ uvx --from 'django-slugify-processor' --prerelease allow django-slugify-proces
 - _Add your latest changes from PRs here_
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Documentation
+
+- Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#417)
+
+
 ### Development
 
 #### Makefile -> Justfile (#411)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ conf = merge_sphinx_config(
     source_branch="master",
     light_logo="img/icons/logo.svg",
     dark_logo="img/icons/logo-dark.svg",
+    extra_extensions=["sphinx_autodoc_api_style"],
     intersphinx_mapping={
         "py": ("https://docs.python.org", None),
         "django": (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ django-extensions = [
 [dependency-groups]
 dev = [
   # Docs
-  "gp-sphinx==0.0.1a6",
-  "sphinx-autodoc-api-style==0.0.1a6",
+  "gp-sphinx==0.0.1a7",
+  "sphinx-autodoc-api-style==0.0.1a7",
   "gp-libs",
   "sphinx-autobuild",
   # Testing
@@ -79,8 +79,8 @@ dev = [
 ]
 
 docs = [
-  "gp-sphinx==0.0.1a6",
-  "sphinx-autodoc-api-style==0.0.1a6",
+  "gp-sphinx==0.0.1a7",
+  "sphinx-autodoc-api-style==0.0.1a7",
   "gp-libs",
   "sphinx-autobuild",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ django-extensions = [
 [dependency-groups]
 dev = [
   # Docs
-  "gp-sphinx==0.0.1a1",
+  "gp-sphinx==0.0.1a5",
+  "sphinx-autodoc-api-style==0.0.1a5",
   "gp-libs",
   "sphinx-autobuild",
   # Testing
@@ -78,7 +79,8 @@ dev = [
 ]
 
 docs = [
-  "gp-sphinx==0.0.1a1",
+  "gp-sphinx==0.0.1a5",
+  "sphinx-autodoc-api-style==0.0.1a5",
   "gp-libs",
   "sphinx-autobuild",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ django-extensions = [
 [dependency-groups]
 dev = [
   # Docs
-  "gp-sphinx==0.0.1a5",
-  "sphinx-autodoc-api-style==0.0.1a5",
+  "gp-sphinx==0.0.1a6",
+  "sphinx-autodoc-api-style==0.0.1a6",
   "gp-libs",
   "sphinx-autobuild",
   # Testing
@@ -79,8 +79,8 @@ dev = [
 ]
 
 docs = [
-  "gp-sphinx==0.0.1a5",
-  "sphinx-autodoc-api-style==0.0.1a5",
+  "gp-sphinx==0.0.1a6",
+  "sphinx-autodoc-api-style==0.0.1a6",
   "gp-libs",
   "sphinx-autobuild",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ dev = [
     { name = "django-extensions" },
     { name = "django-stubs" },
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a5" },
+    { name = "gp-sphinx", specifier = "==0.0.1a6" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -480,13 +480,13 @@ dev = [
     { name = "pytest-watcher" },
     { name = "ruff" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a5" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a6" },
 ]
 docs = [
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a5" },
+    { name = "gp-sphinx", specifier = "==0.0.1a6" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a5" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a6" },
 ]
 lint = [
     { name = "django-stubs" },
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "gp-sphinx"
-version = "0.0.1a5"
+version = "0.0.1a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -609,9 +609,9 @@ dependencies = [
     { name = "sphinxext-opengraph" },
     { name = "sphinxext-rediraffe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/56/a3685ca51045e183caae9d0d996c3edf76653a3851e64ba91e1f2450ffa5/gp_sphinx-0.0.1a5.tar.gz", hash = "sha256:29998304bccc32d0f869109d1ee945263a528765a536665a5dc016fef30decee", size = 13992, upload-time = "2026-04-06T16:55:43.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/84/8bb79a1a7c3fb8da69c8afb776837cf0ac3fa8044ba79687daf30b1b101e/gp_sphinx-0.0.1a6.tar.gz", hash = "sha256:b0f8c9a9a49e5484523e3a9eb4776739a8724831b4912b61540ef6964d0a0478", size = 13993, upload-time = "2026-04-07T01:39:54.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/65/917059394919f7909536fe5a881dd10c7e105a92cba0b5c0eb9c82d85459/gp_sphinx-0.0.1a5-py3-none-any.whl", hash = "sha256:15574494dd25049cf9d7ae47bd892db9cef53a08f5f3129a2cf90ddca4a32bd5", size = 14410, upload-time = "2026-04-06T16:55:32.866Z" },
+    { url = "https://files.pythonhosted.org/packages/12/15/04e2ebcaf8a19af509bc09f75fcfe14121a4201dc357d982e3b9b839dd82/gp_sphinx-0.0.1a6-py3-none-any.whl", hash = "sha256:c3021eab95e88fc29b3c08c183523d18c458abd2fbef2163e1e3938527d201a5", size = 14408, upload-time = "2026-04-07T01:36:41.362Z" },
 ]
 
 [[package]]
@@ -1372,15 +1372,29 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-api-style"
-version = "0.0.1a5"
+version = "0.0.1a6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autodoc-badges" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/74/725982d1e1c96441812ba4bafb962fb12dae03dc48bd4dae7ebb53913791/sphinx_autodoc_api_style-0.0.1a6.tar.gz", hash = "sha256:cdac8845321853e920c1e702ed221b85af841b6906b0a4c161f5ded42da0254f", size = 10923, upload-time = "2026-04-07T01:39:56.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/79/ab4332c04261393766646a45c707b5eb4e258ba993db0ce0e96c0b36027e/sphinx_autodoc_api_style-0.0.1a6-py3-none-any.whl", hash = "sha256:c2aea727076e566cac279be8877f8cb8d41bbc78e91730ec4b026d5e20afcd88", size = 11475, upload-time = "2026-04-07T01:36:44.336Z" },
+]
+
+[[package]]
+name = "sphinx-autodoc-badges"
+version = "0.0.1a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/b9/b980057e09b7b5f6502b78e10193113e594a20117b863edc3b030565f668/sphinx_autodoc_api_style-0.0.1a5.tar.gz", hash = "sha256:d775bcccb24bc7b886fd1a9f4f60be3ed1b7c857d486662c385b5cfd5ad63c4b", size = 11088, upload-time = "2026-04-06T16:55:45.024Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/b4/95d4cf03ad5b80e24024b74a105cc3509f59f3923368f1c41480dea0c65f/sphinx_autodoc_badges-0.0.1a6.tar.gz", hash = "sha256:40883c7b4c0b250e7e9774b4bfa42c84703ce4375d23e24b6c2c38cd320e5ff6", size = 8042, upload-time = "2026-04-07T01:39:57.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/04/53160196a2a8dee73669894d1c34aa478e81af0701640323341a1627c118/sphinx_autodoc_api_style-0.0.1a5-py3-none-any.whl", hash = "sha256:a78d0f83a5038c89daa0cf55c9175bb8aabb9eb47e68ca02a705f478afd30c3c", size = 11679, upload-time = "2026-04-06T16:55:35.855Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/6e3fe1f7e65e218a534a9bcaf11394f30cba213c6dfc4de406f3b0d21ff7/sphinx_autodoc_badges-0.0.1a6-py3-none-any.whl", hash = "sha256:10718d58c8436a3b6855c39b83f4a149c6fcc26e3bc652ccecb5b9f8e5a0e7f3", size = 8365, upload-time = "2026-04-07T01:36:45.779Z" },
 ]
 
 [[package]]
@@ -1473,27 +1487,27 @@ wheels = [
 
 [[package]]
 name = "sphinx-fonts"
-version = "0.0.1a5"
+version = "0.0.1a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/bd/c419420467fe1b249a8261f5253dfe5e17cf3a315cf98f5ce2bd32b85be2/sphinx_fonts-0.0.1a5.tar.gz", hash = "sha256:3e031378a973a6682e866b0260a8ce937276de571f69135bcbcaedfa905da395", size = 5624, upload-time = "2026-04-06T16:55:48.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/4e/acac834c6244c4d7cf0ddd191fa70bdbaa5497c51205e77da99f697b2d64/sphinx_fonts-0.0.1a6.tar.gz", hash = "sha256:e8f2e6461998ab27f1603b8f32824e11ef690568d9b3e679fdb9d0389e26e197", size = 5626, upload-time = "2026-04-07T01:40:02.301Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/6c/6619babd3902262b7159d61f64a183194ee5670c45ab8353b5713e8a5856/sphinx_fonts-0.0.1a5-py3-none-any.whl", hash = "sha256:e8ce3cc7691fcab19cf44c069af4b24b37c0501add6cb8b60f9bbc858f0fb873", size = 4349, upload-time = "2026-04-06T16:55:40.747Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d9/cd9335becec5568fb1b8e1b58228bb0e09b3b37f543861bebd374dfecb64/sphinx_fonts-0.0.1a6-py3-none-any.whl", hash = "sha256:e6ec4866b7c8a13f5193c4adcf0d628a5f8683832d5239d75eee5bd909ae87f0", size = 4346, upload-time = "2026-04-07T01:39:52.244Z" },
 ]
 
 [[package]]
 name = "sphinx-gptheme"
-version = "0.0.1a5"
+version = "0.0.1a6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "furo" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/fb/276020fdaae69e0fd2ac326888e0a478cc594678ff434f5c121457a08dcf/sphinx_gptheme-0.0.1a5.tar.gz", hash = "sha256:ba0303604641efa6a7ebf1f29c6d016abc4d29cf12770223fbc56fccbcba407e", size = 14569, upload-time = "2026-04-06T16:55:49.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/f3/1a5e65c3c8c5d7e0c461a2ae6b6ee657713cb91330bf79f061f6f0678b5a/sphinx_gptheme-0.0.1a6.tar.gz", hash = "sha256:50e3ca26db9130c319116d8276e83261a225d32a349966218404b339fc45589a", size = 14568, upload-time = "2026-04-07T01:40:03.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/bb/d17927243ee476e7909d93d966bb03c8eef5454fc40ac41401e36a7e0dfd/sphinx_gptheme-0.0.1a5-py3-none-any.whl", hash = "sha256:39771734aefe093d3c80060095921f4ff1e276123f5b5f92dc4327996d0e5a94", size = 15628, upload-time = "2026-04-06T16:55:41.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/de/a5c9dabba700fe6dfaac4fb2a76b1f587f76179ca988e686a5b00b0f2be0/sphinx_gptheme-0.0.1a6-py3-none-any.whl", hash = "sha256:32bc5ee4daecf4ab2c187f9cacdee5824aca756d590d0d764827071ab92d8172", size = 15626, upload-time = "2026-04-07T01:39:53.351Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -470,7 +470,7 @@ dev = [
     { name = "django-extensions" },
     { name = "django-stubs" },
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a6" },
+    { name = "gp-sphinx", specifier = "==0.0.1a7" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -480,13 +480,13 @@ dev = [
     { name = "pytest-watcher" },
     { name = "ruff" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a6" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a7" },
 ]
 docs = [
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a6" },
+    { name = "gp-sphinx", specifier = "==0.0.1a7" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a6" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a7" },
 ]
 lint = [
     { name = "django-stubs" },
@@ -588,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "gp-sphinx"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -609,9 +609,9 @@ dependencies = [
     { name = "sphinxext-opengraph" },
     { name = "sphinxext-rediraffe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/84/8bb79a1a7c3fb8da69c8afb776837cf0ac3fa8044ba79687daf30b1b101e/gp_sphinx-0.0.1a6.tar.gz", hash = "sha256:b0f8c9a9a49e5484523e3a9eb4776739a8724831b4912b61540ef6964d0a0478", size = 13993, upload-time = "2026-04-07T01:39:54.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/04/c82ff029d74e0b0bf3e9ea29ec33af8036b07697ab9c5d96fd73ade46f38/gp_sphinx-0.0.1a7.tar.gz", hash = "sha256:c7eea8e35034a194848bb9102776aa11559a3545883f478f3c09b1a9beee06a4", size = 13992, upload-time = "2026-04-11T13:17:01.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/15/04e2ebcaf8a19af509bc09f75fcfe14121a4201dc357d982e3b9b839dd82/gp_sphinx-0.0.1a6-py3-none-any.whl", hash = "sha256:c3021eab95e88fc29b3c08c183523d18c458abd2fbef2163e1e3938527d201a5", size = 14408, upload-time = "2026-04-07T01:36:41.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6b/01d8ab2777abeb83c34c9ddd1a8eea0f49d68c3ed95502ed50e666c71bcf/gp_sphinx-0.0.1a7-py3-none-any.whl", hash = "sha256:c8fda26b6a7213c4774449380059937f28b8e57190474fe2a2f691663a0b5212", size = 14411, upload-time = "2026-04-11T13:16:46.317Z" },
 ]
 
 [[package]]
@@ -1372,29 +1372,29 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-api-style"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autodoc-badges" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/74/725982d1e1c96441812ba4bafb962fb12dae03dc48bd4dae7ebb53913791/sphinx_autodoc_api_style-0.0.1a6.tar.gz", hash = "sha256:cdac8845321853e920c1e702ed221b85af841b6906b0a4c161f5ded42da0254f", size = 10923, upload-time = "2026-04-07T01:39:56.417Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/ba/ac334df39fe2f25f7d5aa5bfc3cfe3ff1cda611f233bcd12118809fba564/sphinx_autodoc_api_style-0.0.1a7.tar.gz", hash = "sha256:8860616f0af7c8bfd340f65008c994e30bbf73a6fd3d851b3f181fceb664580a", size = 10923, upload-time = "2026-04-11T13:17:03.439Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/79/ab4332c04261393766646a45c707b5eb4e258ba993db0ce0e96c0b36027e/sphinx_autodoc_api_style-0.0.1a6-py3-none-any.whl", hash = "sha256:c2aea727076e566cac279be8877f8cb8d41bbc78e91730ec4b026d5e20afcd88", size = 11475, upload-time = "2026-04-07T01:36:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a3/ffb88b803d88374d2a0a361c5b82819a6e0fcbeebe16d368f81750dbc7a5/sphinx_autodoc_api_style-0.0.1a7-py3-none-any.whl", hash = "sha256:4627a148bab6889a0e2ec1b93c4ab12ee0438f04d6c8fbc350eda5c571f531cc", size = 11475, upload-time = "2026-04-11T13:16:49.713Z" },
 ]
 
 [[package]]
 name = "sphinx-autodoc-badges"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/b4/95d4cf03ad5b80e24024b74a105cc3509f59f3923368f1c41480dea0c65f/sphinx_autodoc_badges-0.0.1a6.tar.gz", hash = "sha256:40883c7b4c0b250e7e9774b4bfa42c84703ce4375d23e24b6c2c38cd320e5ff6", size = 8042, upload-time = "2026-04-07T01:39:57.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/23/561cf78ae0b5891cf6722f749c36caaf656aa64b481b37a121414ac890d7/sphinx_autodoc_badges-0.0.1a7.tar.gz", hash = "sha256:7aa04ad728d59023b65a174512497915bc2a9ab6d3160457c4a709ba88d31666", size = 8044, upload-time = "2026-04-11T13:17:04.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/80/6e3fe1f7e65e218a534a9bcaf11394f30cba213c6dfc4de406f3b0d21ff7/sphinx_autodoc_badges-0.0.1a6-py3-none-any.whl", hash = "sha256:10718d58c8436a3b6855c39b83f4a149c6fcc26e3bc652ccecb5b9f8e5a0e7f3", size = 8365, upload-time = "2026-04-07T01:36:45.779Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6f/0c8100492c8567a6e1cd93b76834387e86947eda4e152357798d389d9c61/sphinx_autodoc_badges-0.0.1a7-py3-none-any.whl", hash = "sha256:902f5618cbec522f7aaad64c4fc613238bc3e9faa6085091000adc41eb95aa4d", size = 8365, upload-time = "2026-04-11T13:16:51.268Z" },
 ]
 
 [[package]]
@@ -1487,27 +1487,27 @@ wheels = [
 
 [[package]]
 name = "sphinx-fonts"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/4e/acac834c6244c4d7cf0ddd191fa70bdbaa5497c51205e77da99f697b2d64/sphinx_fonts-0.0.1a6.tar.gz", hash = "sha256:e8f2e6461998ab27f1603b8f32824e11ef690568d9b3e679fdb9d0389e26e197", size = 5626, upload-time = "2026-04-07T01:40:02.301Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/8a/ea86daed70e0039aace2b8143610efebc1f8ce949c365e3907b2a0f58092/sphinx_fonts-0.0.1a7.tar.gz", hash = "sha256:7da3f383a225b623d38c263b3e805620fd0d9b262aa1f3a66bc9bbac2ba44a0b", size = 5624, upload-time = "2026-04-11T13:17:09.822Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/d9/cd9335becec5568fb1b8e1b58228bb0e09b3b37f543861bebd374dfecb64/sphinx_fonts-0.0.1a6-py3-none-any.whl", hash = "sha256:e6ec4866b7c8a13f5193c4adcf0d628a5f8683832d5239d75eee5bd909ae87f0", size = 4346, upload-time = "2026-04-07T01:39:52.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7c/a045b2021cc717cd474378e305e8df4f7b1a0971ef34096cbda8e0bd1c43/sphinx_fonts-0.0.1a7-py3-none-any.whl", hash = "sha256:68c109eb6a9b521e9d9105a08fd89b8dfd1012a058d9fcab49cfb05bd32eec11", size = 4348, upload-time = "2026-04-11T13:16:58.601Z" },
 ]
 
 [[package]]
 name = "sphinx-gptheme"
-version = "0.0.1a6"
+version = "0.0.1a7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "furo" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/f3/1a5e65c3c8c5d7e0c461a2ae6b6ee657713cb91330bf79f061f6f0678b5a/sphinx_gptheme-0.0.1a6.tar.gz", hash = "sha256:50e3ca26db9130c319116d8276e83261a225d32a349966218404b339fc45589a", size = 14568, upload-time = "2026-04-07T01:40:03.366Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/4d/277288688e242b96458ad79f07ce1a003c7d65b9f09c616337b799db8524/sphinx_gptheme-0.0.1a7.tar.gz", hash = "sha256:3b2dee7cdfe5206e0cd83d2ad9d0d44eb802fb0da4cc189b34a8d56ef9770ad6", size = 14569, upload-time = "2026-04-11T13:17:10.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/de/a5c9dabba700fe6dfaac4fb2a76b1f587f76179ca988e686a5b00b0f2be0/sphinx_gptheme-0.0.1a6-py3-none-any.whl", hash = "sha256:32bc5ee4daecf4ab2c187f9cacdee5824aca756d590d0d764827071ab92d8172", size = 15626, upload-time = "2026-04-07T01:39:53.351Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/34/5a88f8f90fd7f70a89834b386be91f110bec12726e747e1c483cb1cccf50/sphinx_gptheme-0.0.1a7-py3-none-any.whl", hash = "sha256:fc2c61d96e3a65c628ed0bc62b414d7cc69089a5be8873f500e6c8ef1a833cc0", size = 15628, upload-time = "2026-04-11T13:17:00.123Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -427,12 +427,14 @@ dev = [
     { name = "ruff" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autodoc-api-style" },
 ]
 docs = [
     { name = "gp-libs" },
     { name = "gp-sphinx" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autodoc-api-style" },
 ]
 lint = [
     { name = "django-stubs" },
@@ -468,7 +470,7 @@ dev = [
     { name = "django-extensions" },
     { name = "django-stubs" },
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a1" },
+    { name = "gp-sphinx", specifier = "==0.0.1a5" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -478,11 +480,13 @@ dev = [
     { name = "pytest-watcher" },
     { name = "ruff" },
     { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a5" },
 ]
 docs = [
     { name = "gp-libs" },
-    { name = "gp-sphinx", specifier = "==0.0.1a1" },
+    { name = "gp-sphinx", specifier = "==0.0.1a5" },
     { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a5" },
 ]
 lint = [
     { name = "django-stubs" },
@@ -584,7 +588,7 @@ wheels = [
 
 [[package]]
 name = "gp-sphinx"
-version = "0.0.1a1"
+version = "0.0.1a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -605,9 +609,9 @@ dependencies = [
     { name = "sphinxext-opengraph" },
     { name = "sphinxext-rediraffe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/89/aa7d03025bbcd036806a67299f04c1de302eda265b35046a1355240503da/gp_sphinx-0.0.1a1.tar.gz", hash = "sha256:70f99cdd2ef5f24aa160da4eb47f80933c8d69bce00383dc0eb60e8bd51663f5", size = 13991, upload-time = "2026-04-05T17:32:41.295Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/56/a3685ca51045e183caae9d0d996c3edf76653a3851e64ba91e1f2450ffa5/gp_sphinx-0.0.1a5.tar.gz", hash = "sha256:29998304bccc32d0f869109d1ee945263a528765a536665a5dc016fef30decee", size = 13992, upload-time = "2026-04-06T16:55:43.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/2a/21836581ec988b8c58cacac2bfb091bbb000b8fe682f62a2fa584674aa6b/gp_sphinx-0.0.1a1-py3-none-any.whl", hash = "sha256:6f0c73a1a13ba94bef7fb1c5368fe6e47dc4128ec948c27f08e834cdf41a2111", size = 14398, upload-time = "2026-04-05T17:32:31.292Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/65/917059394919f7909536fe5a881dd10c7e105a92cba0b5c0eb9c82d85459/gp_sphinx-0.0.1a5-py3-none-any.whl", hash = "sha256:15574494dd25049cf9d7ae47bd892db9cef53a08f5f3129a2cf90ddca4a32bd5", size = 14410, upload-time = "2026-04-06T16:55:32.866Z" },
 ]
 
 [[package]]
@@ -1367,6 +1371,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-autodoc-api-style"
+version = "0.0.1a5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b9/b980057e09b7b5f6502b78e10193113e594a20117b863edc3b030565f668/sphinx_autodoc_api_style-0.0.1a5.tar.gz", hash = "sha256:d775bcccb24bc7b886fd1a9f4f60be3ed1b7c857d486662c385b5cfd5ad63c4b", size = 11088, upload-time = "2026-04-06T16:55:45.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/04/53160196a2a8dee73669894d1c34aa478e81af0701640323341a1627c118/sphinx_autodoc_api_style-0.0.1a5-py3-none-any.whl", hash = "sha256:a78d0f83a5038c89daa0cf55c9175bb8aabb9eb47e68ca02a705f478afd30c3c", size = 11679, upload-time = "2026-04-06T16:55:35.855Z" },
+]
+
+[[package]]
 name = "sphinx-autodoc-typehints"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1456,27 +1473,27 @@ wheels = [
 
 [[package]]
 name = "sphinx-fonts"
-version = "0.0.1a1"
+version = "0.0.1a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/17/c7bdfd74248812b5d7df452d65474817ba96d41ebd67862022938c914465/sphinx_fonts-0.0.1a1.tar.gz", hash = "sha256:2c4ae152636649d88151a1421293b7b147bab36d97ef7aa3e85ce52ce7984dad", size = 5628, upload-time = "2026-04-05T17:32:46.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/bd/c419420467fe1b249a8261f5253dfe5e17cf3a315cf98f5ce2bd32b85be2/sphinx_fonts-0.0.1a5.tar.gz", hash = "sha256:3e031378a973a6682e866b0260a8ce937276de571f69135bcbcaedfa905da395", size = 5624, upload-time = "2026-04-06T16:55:48.726Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/dd/595ac1e9f72c7bc9b19bc9cc2e5c3d429c4d20b9a344674d23b75269906f/sphinx_fonts-0.0.1a1-py3-none-any.whl", hash = "sha256:6b45590254b912fb1b19e08c1ab6c3ce42eb1e1d07333183005d1fd54bb92b6f", size = 4348, upload-time = "2026-04-05T17:32:38.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/6619babd3902262b7159d61f64a183194ee5670c45ab8353b5713e8a5856/sphinx_fonts-0.0.1a5-py3-none-any.whl", hash = "sha256:e8ce3cc7691fcab19cf44c069af4b24b37c0501add6cb8b60f9bbc858f0fb873", size = 4349, upload-time = "2026-04-06T16:55:40.747Z" },
 ]
 
 [[package]]
 name = "sphinx-gptheme"
-version = "0.0.1a1"
+version = "0.0.1a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "furo" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/8d/2bbde808fcc5aadb2e9cdb4c5ae0713ad88f3f57bfbdcfc6f0a4eae82bb2/sphinx_gptheme-0.0.1a1.tar.gz", hash = "sha256:d4b64b6dd6f8c213300820e1300ba075c56428946f4a903d1258440c0a9094d5", size = 14566, upload-time = "2026-04-05T17:32:47.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/fb/276020fdaae69e0fd2ac326888e0a478cc594678ff434f5c121457a08dcf/sphinx_gptheme-0.0.1a5.tar.gz", hash = "sha256:ba0303604641efa6a7ebf1f29c6d016abc4d29cf12770223fbc56fccbcba407e", size = 14569, upload-time = "2026-04-06T16:55:49.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/18/85b1d4550501d7f4a91d75a2ad39e6883e988e4217272e216e5a86b80a49/sphinx_gptheme-0.0.1a1-py3-none-any.whl", hash = "sha256:52a752136bda4641d001d8f32f59f3b492a631fe19cec116ba14c316351ba00d", size = 15624, upload-time = "2026-04-05T17:32:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/d17927243ee476e7909d93d966bb03c8eef5454fc40ac41401e36a7e0dfd/sphinx_gptheme-0.0.1a5-py3-none-any.whl", hash = "sha256:39771734aefe093d3c80060095921f4ff1e276123f5b5f92dc4327996d0e5a94", size = 15628, upload-time = "2026-04-06T16:55:41.81Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adopt the [gp-sphinx](https://gp-sphinx.git-pull.com) Sphinx package stack for django-slugify-processor's API documentation. The net visual effect is card-style autodoc signatures with safety and scope badges, MyST cross-reference roles for Python objects, scoped section names in multi-page CLI docs, and polished IBM Plex typography — all landing together from the `gp-sphinx 0.0.1a7` pre-release.

## What's new

- **API-style autodoc layout** via [`sphinx-autodoc-api-style`](https://gp-sphinx.git-pull.com/packages/sphinx-autodoc-api-style/) — card layouts, badges, MyST roles for Python objects
- **Shared badge layer** via [`sphinx-autodoc-badges`](https://gp-sphinx.git-pull.com/packages/sphinx-autodoc-badges/) — consistent XS/SM/LG/XL size variants with WCAG-AA contrast
- **Multi-page argparse scoping** via [`sphinx-argparse-neo`](https://gp-sphinx.git-pull.com/packages/sphinx-argparse-neo/) — CLI doc builds no longer emit `duplicate label` warnings ([gp-sphinx#16](https://github.com/git-pull/gp-sphinx/pull/16))
- **Font polish** via [`sphinx-fonts`](https://gp-sphinx.git-pull.com/packages/sphinx-fonts/) — IBM Plex Sans and Mono at full weight range, zero-CLS loading

## Verification

- `uv run ruff check . --fix --show-fixes`
- `uv run ruff format .`
- `uv run mypy`
- `uv run py.test --reruns 0 -vvv`
- `just build-docs`

All pass on the branch tip. See [gp-sphinx 0.0.1 release notes](https://github.com/git-pull/gp-sphinx/blob/main/CHANGES) for the full list of changes covering `0.0.1a1..0.0.1a7`.