### PR TITLE
docs(quickstart): clarify slug processor setup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 # Changelog
 
 To install the unreleased django-slugify-processor version, see
-[developmental releases](https://django-slugify-processor.git-pull.com/quickstart.html#developmental-releases).
+{ref}`developmental-releases`.
 
 [pip](https://pip.pypa.io/en/stable/):
 

--- a/CHANGES
+++ b/CHANGES
@@ -71,6 +71,19 @@ code style, and release steps now live as navigable pages instead of one long
 development note, so maintainers can point contributors at the exact workflow
 they need.
 
+#### Clearer slug processor setup guide
+
+The quickstart now explains the processor pipeline directly: start from the
+Django-compatible default, add one processor through `SLUGIFY_PROCESSORS`, then
+use {func}`~django_slugify_processor.text.slugify` from Python or the matching
+template filter from templates. Readers no longer need to leave the docs site
+for the common setup path.
+
+The landing and project pages also link first mentions of API objects,
+Django utilities, and contributor tools to their reference pages. That makes the
+documentation easier to skim while still giving deeper integrators a direct path
+to the details they need.
+
 #### Faster and steadier documentation browsing (#413, #416)
 
 The docs gained the browsing polish first developed locally for this site:

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@
 .. autofunction:: django_slugify_processor.text.slugify
 ```
 
-## Template tag
+## Template filter
 
 ```{eval-rst}
 .. autofunction::

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide-toc: true
 
 # django-slugify-processor
 
-Custom slug processors for Django's `slugify()`.
+Custom slug processors for Django's {func}`slugify() <django.utils.text.slugify>`.
 
 ::::{grid} 1 2 3 3
 :gutter: 2 2 3 3
@@ -14,7 +14,7 @@ Custom slug processors for Django's `slugify()`.
 :::{grid-item-card} Quickstart
 :link: quickstart
 :link-type: doc
-Install, configure processors, and start slugifying.
+Install, learn the pipeline, and start slugifying.
 :::
 
 :::{grid-item-card} API Reference
@@ -43,15 +43,19 @@ $ uv add django-slugify-processor
 
 ## At a glance
 
-Define a processor function:
+With no `SLUGIFY_PROCESSORS` setting, django-slugify-processor keeps Django's
+default slug behavior. Add processors only when a term needs special handling.
+
+Define a processor function that rewrites the text before Django finishes the
+slug:
 
 ```python
-def my_processor(value):
+def my_processor(value: str) -> str:
     value = value.replace("++", "pp")
     return value
 ```
 
-Register it in your Django settings:
+Register it in your [Django settings](https://docs.djangoproject.com/en/4.2/topics/settings/):
 
 ```python
 SLUGIFY_PROCESSORS = [
@@ -59,7 +63,7 @@ SLUGIFY_PROCESSORS = [
 ]
 ```
 
-Use the drop-in replacement for Django's `slugify`:
+Use the drop-in {func}`~django_slugify_processor.text.slugify` replacement:
 
 ```python
 from django_slugify_processor.text import slugify

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -1,10 +1,9 @@
 # Development
 
-[uv] is a required package to develop.
+You need [git] and [uv] to work on django-slugify-processor. Install uv from the
+[installation documentation] if it is not already available.
 
-Install and [git] and [uv]
-
-Clone:
+Clone the repository:
 
 ```console
 $ git clone https://github.com/tony/django-slugify-processor.git
@@ -20,21 +19,33 @@ Install packages:
 $ uv sync --all-extras --dev
 ```
 
-[installation documentation]: https://docs.astral.sh/uv/getting-started/installation/
-[git]: https://git-scm.com/
-
 ## Tests
 
-`uv run py.test`
+Run the test suite directly:
 
-Helpers: `just test`
+```console
+$ uv run py.test
+```
+
+Or use the `just` helper:
+
+```console
+$ just test
+```
 
 ## Automatically run tests on file save
 
-1. `just start` (via [pytest-watcher])
-2. `just watch-test` (requires installing [entr(1)])
+Use [pytest-watcher]:
 
-[pytest-watcher]: https://github.com/olzhasar/pytest-watcher
+```console
+$ just start
+```
+
+Or use [entr(1)]:
+
+```console
+$ just watch-test
+```
 
 ## Documentation
 
@@ -42,21 +53,57 @@ Default preview server: http://localhost:8034
 
 [sphinx-autobuild] will automatically build the docs, watch for file changes and launch a server.
 
-From home directory: `just start-docs`
-From inside `docs/`: `just start`
+From the repository root:
+
+```console
+$ just start-docs
+```
+
+From inside `docs/`:
+
+```console
+$ just start
+```
 
 [sphinx-autobuild]: https://github.com/executablebooks/sphinx-autobuild
 
 ### Manual documentation (the hard way)
 
-`cd docs/` and `just html` to build. `just serve` to start http server.
+Build from inside `docs/`:
+
+```console
+$ cd docs && just html
+```
+
+Start the documentation server from inside `docs/`:
+
+```console
+$ cd docs && just serve
+```
 
 Helpers:
-`just build-docs`, `just serve-docs`
 
-Rebuild docs on file change: `just watch-docs` (requires [entr(1)])
+```console
+$ just build-docs
+```
 
-Rebuild docs and run server via one terminal: `just dev-docs`
+```console
+$ just serve-docs
+```
+
+Rebuild docs on file change:
+
+```console
+$ just watch-docs
+```
+
+This requires [entr(1)].
+
+Rebuild docs and run the server from one terminal:
+
+```console
+$ just dev-docs
+```
 
 ## Formatting / Linting
 
@@ -184,13 +231,16 @@ requires [`entr(1)`].
 [uv] handles virtualenv creation, package requirements, versioning,
 building, and publishing. Therefore there is no setup.py or requirements files.
 
-Update `__version__` in `__about__.py` and `pyproject.toml`::
+Update `__version__` in `__about__.py` and `pyproject.toml`, then commit the
+release:
 
-    git commit -m 'build(django-slugify-processor): Tag v0.1.1'
-    git tag v0.1.1
-    git push
-    git push --tags
+```console
+$ git commit -m 'Tag v0.1.1'
+```
 
+[git]: https://git-scm.com/
+[installation documentation]: https://docs.astral.sh/uv/getting-started/installation/
+[pytest-watcher]: https://github.com/olzhasar/pytest-watcher
 [uv]: https://github.com/astral-sh/uv
 [entr(1)]: http://eradman.com/entrproject/
 [`entr(1)`]: http://eradman.com/entrproject/

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -16,7 +16,7 @@ Development setup, running tests, submitting PRs.
 :::{grid-item-card} Code Style
 :link: code-style
 :link-type: doc
-Ruff, mypy, NumPy docstrings, import conventions.
+[Ruff](https://ruff.rs), [mypy](http://mypy-lang.org/), NumPy docstrings, import conventions.
 :::
 
 :::{grid-item-card} Releasing

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -2,23 +2,26 @@
 
 # Releasing
 
-Releases are published to [PyPI](https://pypi.org/project/django-slugify-processor/) via OIDC-trusted publishing from GitHub Actions.
+Releases are published to [PyPI](https://pypi.org/project/django-slugify-processor/) via OIDC-trusted publishing from [GitHub Actions](https://github.com/features/actions).
 
 ## Steps
 
 1. Update `__version__` in `src/django_slugify_processor/__about__.py` and `version` in `pyproject.toml`.
 
-2. Commit and tag:
+2. Commit the release:
 
 ```console
-$ git commit -m 'build(django-slugify-processor): Tag vX.Y.Z'
+$ git commit -m 'Tag vX.Y.Z'
 ```
+
+AI agents stop after the release commit. The human release maintainer creates
+and pushes tags, because tags trigger the publishing workflow.
 
 ```console
 $ git tag vX.Y.Z
 ```
 
-3. Push:
+3. Push the release commit and tag:
 
 ```console
 $ git push

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,27 +2,33 @@
 
 # Quickstart
 
+django-slugify-processor lets you run small text processors before Django's
+{func}`slugify() <django.utils.text.slugify>` finishes a slug. If you do not
+configure `SLUGIFY_PROCESSORS`, {func}`~django_slugify_processor.text.slugify`
+behaves like Django's function, so you can swap imports first and add processors
+only when a term needs special handling.
+
 ## Installation
 
-For latest official version:
+Install the latest official version from [PyPI]:
 
 ```console
 $ pip install --user django-slugify-processor
 ```
 
-Or using uv:
+Or use [uv]:
 
 ```console
 $ uv tool install django-slugify-processor
 ```
 
-Upgrading:
+Upgrade with [pip]:
 
 ```console
 $ pip install --user --upgrade django-slugify-processor
 ```
 
-Or with uv:
+Or with [uv]:
 
 ```console
 $ uv tool upgrade django-slugify-processor
@@ -32,9 +38,10 @@ $ uv tool upgrade django-slugify-processor
 
 ### Developmental releases
 
-New versions of django-slugify-processor are published to PyPI as alpha, beta, or release candidates.
-In their versions you will see notification like `a1`, `b1`, and `rc1`, respectively.
-`1.10.0b4` would mean the 4th beta release of `1.10.0` before general availability.
+New versions of django-slugify-processor are published to [PyPI] as alpha, beta,
+or release candidates. In their versions you will see labels like `a1`, `b1`,
+and `rc1`; `1.10.0b4` means the fourth beta release of `1.10.0` before general
+availability.
 
 - [pip]\:
 
@@ -45,8 +52,11 @@ In their versions you will see notification like `a1`, `b1`, and `rc1`, respecti
 - [pipx]\:
 
   ```console
-  $ pipx install --suffix=@next 'django-slugify-processor' --pip-args '\--pre' --force
-  // Usage: django-slugify-processor@next [args]
+  $ pipx install \
+      --suffix=@next \
+      --pip-args '\--pre' \
+      --force \
+      'django-slugify-processor'
   ```
 
 - [uv tool install][uv-tools]\:
@@ -64,35 +74,95 @@ In their versions you will see notification like `a1`, `b1`, and `rc1`, respecti
 - [uvx]\:
 
   ```console
-  $ uvx --from 'django-slugify-processor' --prerelease allow django-slugify-processor
+  $ uvx \
+      --from 'django-slugify-processor' \
+      --prerelease allow \
+      django-slugify-processor
   ```
 
-via trunk (can break easily):
+Use trunk only when you need unreleased changes; it can break without notice.
 
 - [pip]\:
 
   ```console
-  $ pip install --user -e git+https://github.com/tony/django-slugify-processor.git#egg=django-slugify-processor
+  $ pip install \
+      --user \
+      -e git+https://github.com/tony/django-slugify-processor.git#egg=django-slugify-processor
   ```
 
 - [pipx]\:
 
   ```console
-  $ pipx install --suffix=@master 'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git@master' --force
+  $ pipx install \
+      --suffix=@master \
+      --force \
+      'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git@master'
   ```
 
 - [uv]\:
 
   ```console
-  $ uv tool install django-slugify-processor --from git+https://github.com/tony/django-slugify-processor.git
+  $ uv tool install \
+      django-slugify-processor \
+      --from git+https://github.com/tony/django-slugify-processor.git
   ```
 
 [pip]: https://pip.pypa.io/en/stable/
 [pipx]: https://pypa.github.io/pipx/docs/
+[pypi]: https://pypi.org/project/django-slugify-processor/
 [uv]: https://docs.astral.sh/uv/
 [uv-tools]: https://docs.astral.sh/uv/concepts/tools/
 [uvx]: https://docs.astral.sh/uv/guides/tools/
 
 ## Usage
 
-For usage instructions, please refer to the [README](https://github.com/tony/django-slugify-processor#readme).
+A processor is a function that takes a string and returns a string. Each
+function in `SLUGIFY_PROCESSORS` runs in order, then Django's
+{func}`~django.utils.text.slugify` turns the final value into a slug.
+
+Create a processor for the term you need to preserve:
+
+```python
+def slugify_programming_languages(value: str) -> str:
+    return value.replace("C++", "Cpp").replace("C#", "CSharp")
+```
+
+Add the processor's import string to your [Django settings]. Django resolves the
+string with {func}`django.utils.module_loading.import_string`.
+
+```python
+SLUGIFY_PROCESSORS = [
+    "myapp.slugify_processors.slugify_programming_languages",
+]
+```
+
+Use {func}`~django_slugify_processor.text.slugify` anywhere you would use
+Django's function:
+
+```python
+from django_slugify_processor.text import slugify
+
+slugify("C++ Programming")
+```
+
+For templates, load the
+{func}`template filter <django_slugify_processor.templatetags.slugify_processor.slugify>`
+when you want this pipeline in one template:
+
+```django
+{% load slugify_processor %}
+{{ "C++ Programming"|slugify }}
+```
+
+For the rarer cases where every template should use this filter, install
+`django_slugify_processor.templatetags.slugify_processor` as a template builtin.
+That shadows Django's `slugify` filter across the configured template engine, so
+reserve it for projects that want the same slug rules everywhere.
+
+For model fields, pass {func}`~django_slugify_processor.text.slugify` to a field
+option such as django-extensions'
+[AutoSlugField `slugify_function`](https://django-extensions.readthedocs.io/en/latest/field_extensions.html)
+or [django-autoslug](https://pypi.org/project/django-autoslug/)'s
+`AutoSlugField` `slugify` argument.
+
+[django settings]: https://docs.djangoproject.com/en/4.2/topics/settings/


### PR DESCRIPTION
## Summary

- Explain the slug processor pipeline directly in the quickstart, starting from the Django-compatible default
- Link first prose mentions of Django utilities, package APIs, and contributor tools to their reference pages
- Clean up contributor and release docs command examples so they stay copyable
- Add a product-level changelog note for the clearer setup path

## Verification

- `rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy .; uv run py.test --reruns 0 -vvv; just build-docs`