### PR TITLE
docs(fix[agents]): tighten docs guidance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -71,7 +71,7 @@ code style, and release steps now live as navigable pages instead of one long
 development note, so maintainers can point contributors at the exact workflow
 they need.
 
-#### Clearer slug processor setup guide
+#### Clearer slug processor setup guide (#421)
 
 The quickstart now explains the processor pipeline directly: start from the
 Django-compatible default, add one processor through `SLUGIFY_PROCESSORS`, then

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ hide-toc: true
 # django-slugify-processor
 
 Custom slug processors for Django's {func}`slugify() <django.utils.text.slugify>`.
+With no `SLUGIFY_PROCESSORS` setting, django-slugify-processor keeps Django's
+default slug behavior, so you can add processors only when a term needs special
+handling.
 
 ::::{grid} 1 2 3 3
 :gutter: 2 2 3 3
@@ -42,9 +45,6 @@ $ uv add django-slugify-processor
 ```
 
 ## At a glance
-
-With no `SLUGIFY_PROCESSORS` setting, django-slugify-processor keeps Django's
-default slug behavior. Add processors only when a term needs special handling.
 
 Define a processor function that rewrites the text before Django finishes the
 slug:

--- a/docs/project/code-style.md
+++ b/docs/project/code-style.md
@@ -2,7 +2,7 @@
 
 # Code Style
 
-## ruff
+## Linting and Formatting
 
 The project uses [ruff](https://ruff.rs) for linting and formatting.
 
@@ -24,7 +24,7 @@ Format:
 $ uv run ruff format .
 ```
 
-## mypy
+## Type Checking
 
 [mypy](http://mypy-lang.org/) is used for static type checking.
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -107,7 +107,7 @@ $ just dev-docs
 
 ## Formatting / Linting
 
-### ruff
+### Linting and Formatting
 
 The project uses [ruff] to handle formatting, sorting imports and linting.
 
@@ -161,7 +161,7 @@ $ ruff check . --fix
 
 ````
 
-#### ruff format
+#### Formatting
 
 [ruff format] is used for formatting.
 
@@ -189,7 +189,7 @@ $ just ruff-format
 
 ````
 
-### mypy
+### Type Checking
 
 [mypy] is used for static type checking.
 

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -14,21 +14,13 @@ Releases are published to [PyPI](https://pypi.org/project/django-slugify-process
 $ git commit -m 'Tag vX.Y.Z'
 ```
 
-AI agents stop after the release commit. The human release maintainer creates
-and pushes tags, because tags trigger the publishing workflow.
+AI agents stop after the release commit. The human release maintainer handles
+tag creation and tag pushes, because tags trigger the publishing workflow.
 
-```console
-$ git tag vX.Y.Z
-```
-
-3. Push the release commit and tag:
+3. Push the release commit:
 
 ```console
 $ git push
-```
-
-```console
-$ git push --tags
 ```
 
 The CI workflow builds the package and publishes it to PyPI automatically.


### PR DESCRIPTION
## Summary

- Move the default slug processor behavior into the landing-page lead
- Retitle tool headings so linked prose owns the first mentions
- Add the missing #421 changelog reference
- Remove explicit tag/tag-push commands from release docs while preserving human maintainer ownership

## Verification

- `rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy .; uv run py.test --reruns 0 -vvv; just build-docs`
- `cd docs && just checkbuild`