### PR TITLE
Fix tested slugify documentation guidance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,32 +6,13 @@ To install the unreleased django-slugify-processor version, see
 [pip](https://pip.pypa.io/en/stable/):
 
 ```console
-$ pip install --user --upgrade --pre django-slugify-processor
-```
-
-[pipx](https://pypa.github.io/pipx/docs/):
-
-```console
-$ pipx install \
-    --suffix=@next \
-    --pip-args '\--pre' \
-    --force \
-    'django-slugify-processor'
+$ python -m pip install --upgrade --pre django-slugify-processor
 ```
 
 [uv](https://docs.astral.sh/uv/):
 
 ```console
 $ uv add django-slugify-processor --prerelease allow
-```
-
-[uvx](https://docs.astral.sh/uv/guides/tools/):
-
-```console
-$ uvx \
-    --from 'django-slugify-processor' \
-    --prerelease allow \
-    django-slugify-processor
 ```
 
 ## django-slugify-processor 1.11.x (unreleased)
@@ -141,9 +122,10 @@ while keeping the existing S3 and CDN deployment model.
 #### Task runner replaces the project Makefiles (#411)
 
 Local development tasks now run through [just](https://just.systems/) at the
-repository root and in `docs/`. The new recipes cover tests, ruff, mypy,
-documentation builds, documentation preview servers, and watch-mode workflows;
-the old root `Makefile` and `docs/Makefile` were removed.
+repository root and in `docs/`. The new recipes cover tests,
+[Ruff](https://ruff.rs), [mypy](http://mypy-lang.org/), documentation builds,
+documentation preview servers, and watch-mode workflows; the old root
+`Makefile` and `docs/Makefile` were removed.
 
 README, contributor docs, CI, and agent guidance now point at the same `just`
 commands, so a maintainer can use one command vocabulary locally and in
@@ -194,8 +176,8 @@ were updated so installers and maintainers see the same compatibility story.
 #### Developmental release installation docs
 
 The changelog gained copyable install commands for pre-release testing via
-`pip`, `pipx`, `uv`, and `uvx`. See {ref}`developmental-releases` for the
-matching quickstart guidance.
+`pip` and `uv`. See {ref}`developmental-releases` for the matching quickstart
+guidance.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # django-slugify-processor
 
-Custom-[`slugify()`](https://docs.djangoproject.com/en/4.2/ref/utils/#django.utils.text.slugify)
-support for django.
+Custom slug processors for Django's
+[`slugify()`](https://docs.djangoproject.com/en/stable/ref/utils/#django.utils.text.slugify).
 
 [![Python Package](https://img.shields.io/pypi/v/django-slugify-processor.svg)](https://pypi.org/project/django-slugify-processor/)
 [![Build Status](https://github.com/tony/django-slugify-processor/workflows/tests/badge.svg)](https://django-slugify-processor.git-pull.com/)
@@ -9,243 +9,116 @@ support for django.
 [![Code Coverage](https://codecov.io/gh/tony/django-slugify-processor/branch/master/graph/badge.svg)](https://codecov.io/gh/tony/django-slugify-processor)
 [![License](https://img.shields.io/github/license/tony/django-slugify-processor.svg)](https://github.com/tony/django-slugify-processor/blob/master/LICENSE)
 
-# What are slugs?
+## Why
 
-_Slugs_ are URL's, typically generated from post titles, that you want to be both human readable and
-a valid URL. They are SEO friendly.
+Django's slugifier is intentionally generic. That means terms such as `C++` and
+`C#` both collapse to `c`, which can produce duplicate or unhelpful slugs.
+django-slugify-processor lets a project run its own small processors before
+Django performs the final slugification step.
 
-Django provides a [`slugify()`](https://docs.djangoproject.com/en/4.2/ref/utils/#django.utils.text.slugify)
-function which is also made available as a [default filter](https://github.com/django/django/blob/4.2.6/django/template/defaultfilters.py#L253-L261).
+With no `SLUGIFY_PROCESSORS` setting, the package behaves like Django's
+`slugify()`.
 
-Django slugs can be automatically generated in django models via packages such as:
-
-- [django-autoslug](https://pypi.python.org/pypi/django-autoslug)
-  ([docs](https://pythonhosted.org/django-autoslug/),
-  [github](https://github.com/neithere/django-autoslug))
-- [django-extensions](https://pypi.python.org/pypi/django-extensions) via
-  [AutoSlugField](https://django-extensions.readthedocs.io/en/latest/field_extensions.html)
-  ([docs](https://django-extensions.readthedocs.io/en/latest/),
-  [github](https://github.com/django-extensions/django-extensions))
-
-# The problem
-
-This project is based on an article from [devel.tech](https://devel.tech) covering
-[django's import strings](https://devel.tech/tips/n/djms3tTe/how-django-uses-deferred-imports-to-scale/).
-
-Corner cases exist with slugification. For instance:
-
-| Term | [`django.utils.text.slugify`] | What you want |
-| ---- | ----------------------------- | ------------- |
-| C    | c (correct)                   | n/a           |
-| C++  | c                             | cpp           |
-| C#   | c                             | c-sharp       |
-
-To make matters worse, if using a specialized model field like `AutoSlugField` from django-autoslug
-or django-extensions, the default behavior may be to name the slugs for C++ and C# to "c-1", "c-2"
-after "c" is taken.
-
-Here's another case, acronyms / shorthands:
-
-| Term               | [`django.utils.text.slugify`] | What you (may) want |
-| ------------------ | ----------------------------- | ------------------- |
-| New York City      | new-york-city                 | nyc                 |
-| Y Combinator       | y-combinator                  | yc                  |
-| Portland           | portland                      | pdx                 |
-| Texas              | texas                         | tx                  |
-| $                  | '' (empty)                    | usd, aud, etc?      |
-| US$                | us                            | usd                 |
-| A$                 | a                             | aud                 |
-| bitcoin            | bitcoin                       | btc                 |
-| United States      | united-states                 | usa                 |
-| League of Legends  | league-of-legends             | league              |
-| Apple® iPod Touch | apple-ipod-touch              | ipod-touch          |
-
-Each website and niche has its own edge cases for slugs. So we need a solution that can scale, where
-you can craft your own functions.
-
-# How django-slugify-processor helps
-
-This builds on top of [`django.utils.text.slugify`] to handle your django project's edgecases. By
-default, django-slugify-processor will be a pass through to django's default behavior. Adding
-slugification functions via your Django project's settings file allows you to adjust.
-
-[`django.utils.text.slugify`]: https://github.com/django/django/blob/4.2.6/django/template/defaultfilters.py#L253-L261
-
-# Installation
+## Install
 
 ```console
-$ pip install django-slugify-processor
+$ python -m pip install django-slugify-processor
 ```
 
-# Configure
+```console
+$ uv add django-slugify-processor
+```
 
-To create a processor, create a function that accepts a string, and returns a string. Assume this is
-_project/app/slugify_processors.py_:
+## Configure
+
+Create a processor that accepts a string and returns a string:
 
 ```python
-def my_processor(value):
-   value = value.replace('++', 'pp')
-   return value
+def slugify_programming_languages(value: str) -> str:
+    return value.replace("C++", "Cpp").replace("C#", "CSharp")
 ```
 
-Inside of your settings, add a `SLUGIFY_PROCESSORS` list of strings that points to the function.
-Anything that's compatible with
-[import_string](https://docs.djangoproject.com/en/4.2/ref/utils/#django.utils.module_loading.import_string),
-in your settings file:
+Register the processor's import string in Django settings:
 
 ```python
 SLUGIFY_PROCESSORS = [
-   'project.app.slugify_processors.my_processor'
+    "myapp.slugify_processors.slugify_programming_languages",
 ]
 ```
 
-# Usage
+Processors run in list order. The result then passes through Django's own
+`slugify()`, including its `allow_unicode` handling.
 
-## In normal django code
+## Use
 
-Import `slugify` from `django_slugify_processor.text`:
+Use the Python helper anywhere you would use Django's slugifier:
 
 ```python
 from django_slugify_processor.text import slugify
 
-print(slugify('C++'))
-> 'cpp'
+slugify("C++ Programming")  # "cpp-programming"
 ```
 
-## Template code
-
-django-slugify-processor is designed to override the built-in`slugify` filter.
-
-### via load
-
-You can load by default via `{% load django_slugify_processor %}` in your template.
-
-In your settings `INSTALLED_APPS`:
-
-```python
-INSTALLED_APPS = [
-    'django_slugify_processor'
-]
-```
-
-In your template:
+Load the template filter in a template that needs the same pipeline:
 
 ```django
 {% load slugify_processor %}
-{{"C++"|slugify}}
+{{ "C++ Programming"|slugify }}
 ```
 
-### via built-in
-
-To make this available in all templates, in the `OPTIONS` of your template engine, add
-`django_slugify_processor.template_tags`:
+For projects that want every template to use this filter, install it as a
+template builtin:
 
 ```python
-TEMPLATES = [{
-    'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'OPTIONS': {
-        'builtins': [
-            'django_slugify_processor.templatetags.slugify_processor',
-        ],
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "builtins": [
+                "django_slugify_processor.templatetags.slugify_processor",
+            ],
+        },
     },
-}]
+]
 ```
 
-From within the template file:
-
-```django
-{{"C++"|slugify}}
-```
-
-Output should be: cpp
-
-## Models
-
-For the most up to date documentation, view the documentation for the plugin you're using (e.g.
-django-autoslug or django-extensions).
-
-To use django-slugify-processor's `slugify` instead of django's default, there will be a field
-option to use the function.
-
-### django-extensions
-
-Tested with 1.9.7 (2017-11-26):
+Model-field packages usually accept a slugify callback. For django-extensions:
 
 ```python
 from django.db import models
-
 from django_extensions.db.fields import AutoSlugField
-from django_slugify_processors.text import slugify
+from django_slugify_processor.text import slugify
 
-class MyModel(models.Model):
+
+class Article(models.Model):
     title = models.CharField(max_length=255)
-    slug = AutoSlugField(
-        populate_from='title',
-        slugify_function=slugify
-    )
+    slug = AutoSlugField(populate_from="title", slugify_function=slugify)
 ```
 
-### django-autoslug
+For django-autoslug, pass the same function to its `slugify` option.
 
-Tested with 1.9.3 (2017-11-26):
+## Links
 
-```python
-from django.db import models
-
-from autoslug import AutoSlugField
-from django_slugify_processors.text import slugify
-
-class MyModel(models.Model):
-    title = models.CharField(max_length=255)
-    slug = AutoSlugField(
-        populate_from='title',
-        slugify=slugify
-    )
-```
-
-# Credits
-
-- tox.ini based off DRF's (BSD 2-clause licensed)
-- yapf configuration based off RTD / devel.tech's (MIT-licensed)
-
-# Project details
-
-- python support >= 3.10, pypy3
-- django support >= 4.2
-- Source https://github.com/tony/django-slugify-processor
-- Docs https://django-slugify-processor.git-pull.com
-- API https://django-slugify-processor.git-pull.com/api.html
-- Changelog https://django-slugify-processor.git-pull.com/history.html
-- Issues https://github.com/tony/django-slugify-processor/issues
-- Test Coverage https://codecov.io/gh/tony/django-slugify-processor
-- pypi https://pypi.python.org/pypi/django-slugify-processor
-- Open Hub https://www.openhub.net/p/django-slugify-processor
-- License MIT
-- git repo
-
-  ```console
-  $ git clone https://github.com/tony/django-slugify-processor.git
-  ```
+- Documentation: https://django-slugify-processor.git-pull.com
+- API reference: https://django-slugify-processor.git-pull.com/api.html
+- Changelog: https://django-slugify-processor.git-pull.com/history.html
+- Source: https://github.com/tony/django-slugify-processor
+- Issues: https://github.com/tony/django-slugify-processor/issues
+- PyPI: https://pypi.org/project/django-slugify-processor/
 
 ## Development
-
-Install stable:
-
-```console
-$ pip install django-slugify-processor
-```
-
-Local installation:
 
 ```console
 $ git clone https://github.com/tony/django-slugify-processor.git
 ```
 
 ```console
-$ cd ./django-slugify-processor
+$ cd django-slugify-processor
 ```
 
-Test:
+```console
+$ uv sync --all-extras --dev
+```
 
 ```console
 $ just test

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,10 +66,10 @@ common case pay a comprehension tax for the advanced one.
 
 ## Examples that run
 
-Doctests on pages under `docs/` execute: `testpaths` in
-`pyproject.toml` includes `docs`, and gp-libs' doctest collector
-picks up `>>>` examples in Markdown. `just test` runs them alongside
-the suite, so a wrong example fails loudly.
+Doctests on pages under `docs/` execute through
+`just -f docs/justfile doctest`, and pytest runs Python docstrings
+through `--doctest-modules`. A wrong example should fail loudly before
+the docs are considered complete.
 
 - There are no `doctest_namespace` fixtures in this repo — import
   what you use (`from django_slugify_processor.text import slugify`).
@@ -77,10 +77,11 @@ the suite, so a wrong example fails loudly.
   which set no `SLUGIFY_PROCESSORS` — a bare example shows the
   pass-through default. An example that needs a processor must
   configure one itself, e.g. with `django.test.override_settings`.
-- Fence a `>>>` session as a ```` ```python ```` block; `ELLIPSIS`
-  and `NORMALIZE_WHITESPACE` are already on via `doctest_optionflags`
-  in `pyproject.toml`. Use a ```` ```console ```` block for shell
-  commands at a `$` prompt.
+- Use a ```` ```{doctest} ```` directive for docs-page `>>>`
+  sessions that must run through Sphinx. `ELLIPSIS` and
+  `NORMALIZE_WHITESPACE` are already on via `doctest_optionflags` in
+  `pyproject.toml`. Use a ```` ```console ```` block for shell commands
+  at a `$` prompt.
 
 ## What stays precise
 
@@ -133,7 +134,7 @@ the surrounding prose instead.
   be named by concept instead?
 - Are the template-builtin and model-field parts clearly marked
   opt-in?
-- Do the doctests pass under `just test`, and did you leave every
-  code block, table, and cross-reference exact?
+- Do `just test` and `just -f docs/justfile doctest` pass, and did you
+  leave every code block, table, and cross-reference exact?
 - Did `just build-docs` stay clean — no new warning, no broken
   cross-reference?

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,21 @@
 
 # API Reference
 
+## Processor Pipeline
+
+`SLUGIFY_PROCESSORS` is a Django setting containing dotted import strings. Each
+string must resolve through {func}`django.utils.module_loading.import_string` to
+a callable that accepts a `str` and returns a `str`.
+
+Processors run in list order for every {func}`~django_slugify_processor.text.slugify`
+call. Each processor receives the previous processor's output, then the final
+value passes to {func}`django.utils.text.slugify` with the caller's
+`allow_unicode` value.
+
+Keep processors pure and inexpensive. A processor should not depend on request
+state, database writes, or network calls because slugification can run inside
+model-field saves, template rendering, and bulk import jobs.
+
 ## Slugify function
 
 ```{eval-rst}
@@ -9,6 +24,12 @@
 ```
 
 ## Template filter
+
+The template filter delegates to {func}`~django_slugify_processor.text.slugify`
+with its default `allow_unicode=False` behavior. Load it explicitly with
+`{% load slugify_processor %}`, or install
+`django_slugify_processor.templatetags.slugify_processor` as a template builtin
+when the whole template engine should shadow Django's built-in `slugify` filter.
 
 ```{eval-rst}
 .. autofunction::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 
@@ -14,6 +15,8 @@ cwd = pathlib.Path(__file__).parent
 project_root = cwd.parent
 src_root = project_root / "src"
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(src_root))
 
 # package data
@@ -30,7 +33,7 @@ conf = merge_sphinx_config(
     source_branch="master",
     light_logo="img/icons/logo.svg",
     dark_logo="img/icons/logo-dark.svg",
-    extra_extensions=["sphinx_autodoc_api_style"],
+    extra_extensions=["sphinx.ext.doctest", "sphinx_autodoc_api_style"],
     intersphinx_mapping={
         "py": ("https://docs.python.org", None),
         "django": (
@@ -48,4 +51,11 @@ conf = merge_sphinx_config(
     # treating it as an orphan document.
     exclude_patterns=["_build", "AGENTS.md", "CLAUDE.md"],
 )
+conf["doctest_global_setup"] = """
+import django
+from django.apps import apps
+
+if not apps.ready:
+    django.setup()
+"""
 globals().update(conf)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Development setup, code style, release process.
 ## Install
 
 ```console
-$ pip install django-slugify-processor
+$ python -m pip install django-slugify-processor
 ```
 
 ```console
@@ -49,13 +49,15 @@ $ uv add django-slugify-processor
 Define a processor function that rewrites the text before Django finishes the
 slug:
 
-```python
-def my_processor(value: str) -> str:
-    value = value.replace("++", "pp")
-    return value
+```{doctest}
+>>> def my_processor(value: str) -> str:
+...     return value.replace("C++", "Cpp")
+>>> my_processor("C++")
+'Cpp'
 ```
 
-Register it in your [Django settings](https://docs.djangoproject.com/en/4.2/topics/settings/):
+Register the processor's import string in your
+[Django settings](https://docs.djangoproject.com/en/4.2/topics/settings/):
 
 ```python
 SLUGIFY_PROCESSORS = [
@@ -65,10 +67,14 @@ SLUGIFY_PROCESSORS = [
 
 Use the drop-in {func}`~django_slugify_processor.text.slugify` replacement:
 
-```python
-from django_slugify_processor.text import slugify
-
-slugify("C++")  # 'cpp'
+```{doctest}
+>>> from django.test import override_settings
+>>> from django_slugify_processor.text import slugify
+>>> with override_settings(
+...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming_languages"],
+... ):
+...     slugify("C++")
+'cpp'
 ```
 
 ```{toctree}

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -19,6 +19,17 @@ Install packages:
 $ uv sync --all-extras --dev
 ```
 
+## Codebase Map
+
+The slugification behavior lives in `src/django_slugify_processor/text.py`.
+Template integration lives in
+`src/django_slugify_processor/templatetags/slugify_processor.py`, which delegates
+to the same Python helper so templates and Python code do not diverge.
+
+Tests live in `tests/`, with importable example processors in `test_app/`.
+Documentation pages live in `docs/`; API pages are generated from docstrings,
+and runnable docs examples are checked by the `docs/` doctest recipe.
+
 ## Tests
 
 Run the test suite directly:
@@ -116,7 +127,7 @@ The project uses [ruff] to handle formatting, sorting imports and linting.
 uv:
 
 ```console
-$ uv run ruff
+$ uv run ruff check .
 ```
 
 If you setup manually:
@@ -231,8 +242,10 @@ requires [`entr(1)`].
 [uv] handles virtualenv creation, package requirements, versioning,
 building, and publishing. Therefore there is no setup.py or requirements files.
 
-Update `__version__` in `__about__.py` and `pyproject.toml`, then commit the
-release:
+See {ref}`releasing` for the release checklist. Update
+{data}`django_slugify_processor.__version__` in
+`src/django_slugify_processor/__about__.py` and `version` in `pyproject.toml`,
+then commit the release:
 
 ```console
 $ git commit -m 'Tag v0.1.1'

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -8,7 +8,7 @@ via [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) from
 
 ## Steps
 
-1. Update `__version__` in `src/django_slugify_processor/__about__.py` and `version` in `pyproject.toml`.
+1. Update {data}`django_slugify_processor.__version__` in `src/django_slugify_processor/__about__.py` and `version` in `pyproject.toml`.
 
 2. Commit the release:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,109 +10,34 @@ only when a term needs special handling.
 
 ## Installation
 
-Install the latest official version from [PyPI]:
+Add django-slugify-processor to the Python environment that runs your Django
+project.
+
+With [pip]:
 
 ```console
-$ pip install --user django-slugify-processor
+$ python -m pip install django-slugify-processor
 ```
 
-Or use [uv]:
+With [uv]:
 
 ```console
-$ uv tool install django-slugify-processor
+$ uv add django-slugify-processor
 ```
 
-Upgrade with [pip]:
+Upgrade an existing environment with [pip]:
 
 ```console
-$ pip install --user --upgrade django-slugify-processor
+$ python -m pip install --upgrade django-slugify-processor
 ```
 
-Or with [uv]:
+Upgrade an existing [uv] dependency:
 
 ```console
-$ uv tool upgrade django-slugify-processor
+$ uv add \
+    --upgrade-package django-slugify-processor \
+    django-slugify-processor
 ```
-
-(developmental-releases)=
-
-### Developmental releases
-
-New versions of django-slugify-processor are published to [PyPI] as alpha, beta,
-or release candidates. In their versions you will see labels like `a1`, `b1`,
-and `rc1`; `1.10.0b4` means the fourth beta release of `1.10.0` before general
-availability.
-
-- [pip]\:
-
-  ```console
-  $ pip install --user --upgrade --pre django-slugify-processor
-  ```
-
-- [pipx]\:
-
-  ```console
-  $ pipx install \
-      --suffix=@next \
-      --pip-args '\--pre' \
-      --force \
-      'django-slugify-processor'
-  ```
-
-- [uv tool install][uv-tools]\:
-
-  ```console
-  $ uv tool install --prerelease=allow django-slugify-processor
-  ```
-
-- [uv]\:
-
-  ```console
-  $ uv add django-slugify-processor --prerelease allow
-  ```
-
-- [uvx]\:
-
-  ```console
-  $ uvx \
-      --from 'django-slugify-processor' \
-      --prerelease allow \
-      django-slugify-processor
-  ```
-
-Use trunk only when you need unreleased changes; it can break without notice.
-
-- [pip]\:
-
-  ```console
-  $ pip install \
-      --user \
-      -e git+https://github.com/tony/django-slugify-processor.git#egg=django-slugify-processor
-  ```
-
-- [pipx]\:
-
-  ```console
-  $ pipx install \
-      --suffix=@master \
-      --force \
-      'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git@master'
-  ```
-
-- [uv]\:
-
-  ```console
-  $ uv tool install \
-      django-slugify-processor \
-      --from git+https://github.com/tony/django-slugify-processor.git
-  ```
-
-[pip]: https://pip.pypa.io/en/stable/
-[pipx]: https://pypa.github.io/pipx/docs/
-[pypi]: https://pypi.org/project/django-slugify-processor/
-[uv]: https://docs.astral.sh/uv/
-[uv-tools]: https://docs.astral.sh/uv/concepts/tools/
-[uvx]: https://docs.astral.sh/uv/guides/tools/
 
 ## Usage
 
@@ -120,11 +45,14 @@ A processor is a function that takes a string and returns a string. Each
 function in `SLUGIFY_PROCESSORS` runs in order, then Django's
 {func}`~django.utils.text.slugify` turns the final value into a slug.
 
-Create a processor for the term you need to preserve:
+Start with the term you need to preserve. This processor makes `C++` become
+`Cpp` before Django strips punctuation:
 
-```python
-def slugify_programming_languages(value: str) -> str:
-    return value.replace("C++", "Cpp").replace("C#", "CSharp")
+```{doctest}
+>>> def slugify_programming_languages(value: str) -> str:
+...     return value.replace("C++", "Cpp").replace("C#", "CSharp")
+>>> slugify_programming_languages("C++ Programming")
+'Cpp Programming'
 ```
 
 Add the processor's import string to your [Django settings]. Django resolves the
@@ -137,21 +65,51 @@ SLUGIFY_PROCESSORS = [
 ```
 
 Use {func}`~django_slugify_processor.text.slugify` anywhere you would use
-Django's function:
+Django's function. This tested example uses the repository's `test_app`
+processor; in an application, point `SLUGIFY_PROCESSORS` at your own module.
 
-```python
-from django_slugify_processor.text import slugify
-
-slugify("C++ Programming")
+```{doctest}
+>>> from django.test import override_settings
+>>> from django_slugify_processor.text import slugify
+>>> with override_settings(
+...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming_languages"],
+... ):
+...     slugify("C++ Programming")
+'cpp-programming'
 ```
+
+Processors should stay pure and fast. The list is read for each slugification
+call, each import string is resolved with Django's import helper, and each
+processor receives the previous processor's output.
+
+## Templates
 
 For templates, load the
 {func}`template filter <django_slugify_processor.templatetags.slugify_processor.slugify>`
 when you want this pipeline in one template:
 
-```django
-{% load slugify_processor %}
-{{ "C++ Programming"|slugify }}
+```{doctest}
+>>> from django.template import Context, Template
+>>> from django.test import override_settings
+>>> with override_settings(
+...     INSTALLED_APPS=[
+...         "django.contrib.contenttypes",
+...         "django.contrib.auth",
+...         "test_app",
+...         "django_slugify_processor",
+...     ],
+...     TEMPLATES=[
+...         {
+...             "BACKEND": "django.template.backends.django.DjangoTemplates",
+...             "APP_DIRS": True,
+...         },
+...     ],
+...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming_languages"],
+... ):
+...     Template(
+...         '{% load slugify_processor %}{{ "C++ Programming"|slugify }}',
+...     ).render(Context({}))
+'cpp-programming'
 ```
 
 For the rarer cases where every template should use this filter, install
@@ -159,10 +117,79 @@ For the rarer cases where every template should use this filter, install
 That shadows Django's `slugify` filter across the configured template engine, so
 reserve it for projects that want the same slug rules everywhere.
 
+```python
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {
+            "builtins": [
+                "django_slugify_processor.templatetags.slugify_processor",
+            ],
+        },
+    },
+]
+```
+
+## Model Fields
+
 For model fields, pass {func}`~django_slugify_processor.text.slugify` to a field
 option such as django-extensions'
 [AutoSlugField `slugify_function`](https://django-extensions.readthedocs.io/en/latest/field_extensions.html)
 or [django-autoslug](https://pypi.org/project/django-autoslug/)'s
 `AutoSlugField` `slugify` argument.
 
+```python
+from django.db import models
+from django_extensions.db.fields import AutoSlugField
+from django_slugify_processor.text import slugify
+
+
+class Article(models.Model):
+    title = models.CharField(max_length=255)
+    slug = AutoSlugField(populate_from="title", slugify_function=slugify)
+```
+
+(developmental-releases)=
+
+## Advanced: Developmental Releases
+
+New versions of django-slugify-processor are published to [PyPI] as alpha, beta,
+or release candidates. In their versions you will see labels like `a1`, `b1`,
+and `rc1`; `1.10.0b4` means the fourth beta release of `1.10.0` before general
+availability.
+
+Install the latest prerelease with [pip]:
+
+```console
+$ python -m pip install --upgrade --pre django-slugify-processor
+```
+
+Or allow prereleases in a [uv] project dependency:
+
+```console
+$ uv add \
+    --prerelease allow \
+    django-slugify-processor
+```
+
+Use trunk only when you need unreleased changes; it can break without notice.
+
+With [pip]:
+
+```console
+$ python -m pip install \
+    --upgrade \
+    'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git'
+```
+
+With [uv]:
+
+```console
+$ uv add \
+    'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git'
+```
+
 [django settings]: https://docs.djangoproject.com/en/4.2/topics/settings/
+[pip]: https://pip.pypa.io/en/stable/
+[pypi]: https://pypi.org/project/django-slugify-processor/
+[uv]: https://docs.astral.sh/uv/

--- a/src/django_slugify_processor/templatetags/slugify_processor.py
+++ b/src/django_slugify_processor/templatetags/slugify_processor.py
@@ -13,30 +13,43 @@ register = template.Library()
 @register.filter(is_safe=True)
 @stringfilter
 def slugify(value: str) -> str:
-    """Template filter override for Django's :func:`django.utils.text.slugify()`.
+    """Template filter override for Django's :func:`django.utils.text.slugify`.
 
-    Can be installed via a builtin, or via ``{% load slugify_processor %}``.
+    Install via a template builtin, or load with ``{% load slugify_processor %}``.
 
     Parameters
     ----------
     value : str
-        A value such as an article name or page title, to "slugify", (turn into a
-        clean, URL-friendly short name)
+        A value such as an article name or page title to turn into a clean,
+        URL-friendly short name.
 
     Returns
     -------
     str
-        Clean, URL-friendly short name (a.k.a. "slug") of a string (e.g. a page or
-        article name).
+        Clean, URL-friendly short name.
 
     Examples
     --------
-    Usage in a Django template:
-
-    .. code-block:: django
-
-       {% load slugify_processor %}
-       {{ variable|slugify }}
-       {{ "C++"|slugify }}
+    >>> from django.template import Context, Template
+    >>> from django.test import override_settings
+    >>> with override_settings(
+    ...     INSTALLED_APPS=[
+    ...         "django.contrib.contenttypes",
+    ...         "django.contrib.auth",
+    ...         "test_app",
+    ...         "django_slugify_processor",
+    ...     ],
+    ...     TEMPLATES=[
+    ...         {
+    ...             "BACKEND": "django.template.backends.django.DjangoTemplates",
+    ...             "APP_DIRS": True,
+    ...         },
+    ...     ],
+    ...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming_languages"],
+    ... ):
+    ...     Template(
+    ...         '{% load slugify_processor %}{{ "C++ Guide"|slugify }}',
+    ...     ).render(Context({}))
+    'cpp-guide'
     """
     return _slugify(value)

--- a/src/django_slugify_processor/text.py
+++ b/src/django_slugify_processor/text.py
@@ -8,63 +8,49 @@ from django.utils.text import slugify as django_slugify
 
 
 def slugify(value: str, allow_unicode: bool = False) -> str:
-    """Override default slugify in django to handle custom scenarios.
+    """Override Django's default slugify behavior with custom processors.
 
-    Run value through functions declared in ``SLUGIFY_PROCESSORS`` setting. The value is
-    then passed-through to Django's :func:`django.utils.text.slugify()`.
+    Run ``value`` through functions declared in ``SLUGIFY_PROCESSORS``. The
+    value then passes to Django's :func:`django.utils.text.slugify`.
 
     Parameters
     ----------
     value : str
-        A value such as an article name or page title, to "slugify", (turn into a
-        clean, URL-friendly short name)
+        A value such as an article name or page title to turn into a clean,
+        URL-friendly short name.
     allow_unicode : bool
-        Whether or not to allow unicode (e.g. chinese).
+        Whether to allow Unicode characters in Django's final slugification
+        step.
 
     Returns
     -------
     str
-        Clean, URL-friendly short name (a.k.a. "slug") of a string (e.g. a page or
-        article name).
+        Clean, URL-friendly short name.
 
     Examples
     --------
-    Examples of slugify processors, assume *project/app/slugify_processors.py*:
+    With no processors configured, this matches Django's slugifier:
 
-    .. code-block:: python
+    >>> from django_slugify_processor.text import slugify
+    >>> slugify("c++")
+    'c'
 
-        def slugify_programming_languages(value):
-            value = value.lower()
+    Processors run before Django's final slugification:
 
-            value = value.replace('c++', 'cpp')
-            value = value.replace('c#', 'c-sharp')
-            return value
+    >>> from django.test import override_settings
+    >>> with override_settings(
+    ...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming"],
+    ... ):
+    ...     slugify("c++")
+    'cpp'
 
-        def slugify_geo_acronyms(value):
-            value = value.lower()
+    The ``allow_unicode`` flag is passed to Django after processors run:
 
-            value = value.replace('New York City', 'nyc')
-            value = value.replace('United States', 'usa')
-            return value
-
-        def slugify_us_currency(value):
-            value = value.lower()
-
-            value = value.replace('$', 'usd')
-            value = value.replace('US$', 'usd')
-            value = value.replace('US Dollar', 'usd')
-            value = value.replace('U.S. Dollar', 'usd')
-            return value
-
-    Settings:
-
-    .. code-block:: python
-
-        SLUGIFY_PROCESSORS = [
-            'project.app.slugify_programming_languages',
-            'project.app.slugify_geo_acronyms',
-            'project.app.slugify_us_currency',
-        ]
+    >>> with override_settings(
+    ...     SLUGIFY_PROCESSORS=["test_app.coding.slugify_programming"],
+    ... ):
+    ...     slugify("東京 c++", allow_unicode=True)
+    '東京-cpp'
     """
     slugify_processors = getattr(settings, "SLUGIFY_PROCESSORS", [])
     for slugify_fn_str in slugify_processors:

--- a/test_app/coding.py
+++ b/test_app/coding.py
@@ -4,5 +4,33 @@ from __future__ import annotations
 
 
 def slugify_programming(value: str) -> str:
-    """Replace c++ with cpp (URL safe)."""
+    """Replace c++ with cpp.
+
+    Examples
+    --------
+    >>> slugify_programming("c++")
+    'cpp'
+    """
     return value.replace("c++", "cpp")
+
+
+def slugify_programming_languages(value: str) -> str:
+    """Replace common language names before Django finishes the slug.
+
+    Examples
+    --------
+    >>> slugify_programming_languages("C++ and C#")
+    'Cpp and CSharp'
+    """
+    return value.replace("C++", "Cpp").replace("C#", "CSharp")
+
+
+def slugify_language_suffix(value: str) -> str:
+    """Append a language suffix after the programming-language processor.
+
+    Examples
+    --------
+    >>> slugify_language_suffix("Cpp Guide")
+    'Cpp Language Guide'
+    """
+    return value.replace("Cpp", "Cpp Language").replace("cpp", "cpp language")

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -54,12 +54,22 @@ def test_library_install_docs_do_not_recommend_tool_installers(
         assert forbidden_command not in text
 
 
-def test_sphinx_doctest_recipe_runs() -> None:
-    """Assert docs/ doctest examples run through the documented recipe."""
+def test_sphinx_doctest_builder_runs() -> None:
+    """Assert docs/ doctest examples run without requiring external just."""
     completed = subprocess.run(
-        ["just", "-f", "docs/justfile", "doctest"],
+        [
+            "uv",
+            "run",
+            "sphinx-build",
+            "-b",
+            "doctest",
+            "-d",
+            "_build/doctrees",
+            ".",
+            "_build/doctest",
+        ],
         check=False,
-        cwd=PROJECT_ROOT,
+        cwd=PROJECT_ROOT / "docs",
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         text=True,

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,68 @@
+"""Regression tests for documentation examples and commands."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import typing as t
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class DocsInstallCase(t.NamedTuple):
+    """Documentation install-command test case."""
+
+    test_id: str
+    path: pathlib.Path
+    section_marker: str | None
+    forbidden_commands: tuple[str, ...]
+
+
+DOCS_INSTALL_CASES = (
+    DocsInstallCase(
+        test_id="quickstart-library-install",
+        path=PROJECT_ROOT / "docs" / "quickstart.md",
+        section_marker=None,
+        forbidden_commands=("$ uv tool", "$ pipx", "$ uvx"),
+    ),
+    DocsInstallCase(
+        test_id="unreleased-changelog-library-install",
+        path=PROJECT_ROOT / "CHANGES",
+        section_marker="## django-slugify-processor 1.10.0 (2025-11-01)",
+        forbidden_commands=("$ pipx", "$ uvx"),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    DOCS_INSTALL_CASES,
+    ids=[case.test_id for case in DOCS_INSTALL_CASES],
+)
+def test_library_install_docs_do_not_recommend_tool_installers(
+    case: DocsInstallCase,
+) -> None:
+    """Assert library install docs do not use Python tool-runner commands."""
+    text = case.path.read_text()
+    if case.section_marker is not None:
+        assert case.section_marker in text
+        text = text.split(case.section_marker, maxsplit=1)[0]
+
+    for forbidden_command in case.forbidden_commands:
+        assert forbidden_command not in text
+
+
+def test_sphinx_doctest_recipe_runs() -> None:
+    """Assert docs/ doctest examples run through the documented recipe."""
+    completed = subprocess.run(
+        ["just", "-f", "docs/justfile", "doctest"],
+        check=False,
+        cwd=PROJECT_ROOT,
+        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE,
+        text=True,
+        timeout=120,
+    )
+    assert completed.returncode == 0, completed.stdout

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,17 +4,70 @@ from __future__ import annotations
 
 import typing as t
 
+import pytest
 from django.utils.text import slugify as django_slugify
 
 from django_slugify_processor.text import slugify
 
 
-def test_slugify_fallback_to_default() -> None:
-    """Assert slugify() falls back to django's behavior."""
-    assert slugify("c++") == django_slugify("c++")
+class SlugifyCase(t.NamedTuple):
+    """Slugify behavior test case."""
+
+    test_id: str
+    value: str
+    processors: tuple[str, ...]
+    allow_unicode: bool
+    expected: str
 
 
-def test_slugify_slugify_processors(settings: t.Any) -> None:
-    """Assert slugify() follows SLUGIFY_PROCESSORS."""
-    settings.SLUGIFY_PROCESSORS = ["test_app.coding.slugify_programming"]
-    assert slugify("c++") == "cpp"
+SLUGIFY_CASES = (
+    SlugifyCase(
+        test_id="fallback-ascii",
+        value="c++",
+        processors=(),
+        allow_unicode=False,
+        expected=django_slugify("c++"),
+    ),
+    SlugifyCase(
+        test_id="single-processor",
+        value="c++",
+        processors=("test_app.coding.slugify_programming",),
+        allow_unicode=False,
+        expected="cpp",
+    ),
+    SlugifyCase(
+        test_id="processor-order",
+        value="C++ Guide",
+        processors=(
+            "test_app.coding.slugify_programming_languages",
+            "test_app.coding.slugify_language_suffix",
+        ),
+        allow_unicode=False,
+        expected="cpp-language-guide",
+    ),
+    SlugifyCase(
+        test_id="unicode-pass-through-without-processors",
+        value="東京 c++",
+        processors=(),
+        allow_unicode=True,
+        expected=django_slugify("東京 c++", allow_unicode=True),
+    ),
+    SlugifyCase(
+        test_id="unicode-pass-through-with-processor",
+        value="東京 c++",
+        processors=("test_app.coding.slugify_programming",),
+        allow_unicode=True,
+        expected="東京-cpp",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case",
+    SLUGIFY_CASES,
+    ids=[case.test_id for case in SLUGIFY_CASES],
+)
+def test_slugify_pipeline_cases(settings: t.Any, case: SlugifyCase) -> None:
+    """Assert slugify() applies processors before Django's final slugifier."""
+    settings.SLUGIFY_PROCESSORS = list(case.processors)
+    assert slugify(case.value, allow_unicode=case.allow_unicode) == case.expected


### PR DESCRIPTION
## Summary
- Replace command-runner install examples with project dependency install guidance.
- Enable Sphinx doctest and make quickstart, landing, and API examples executable.
- Add pytest coverage for docs install regressions, processor ordering, and allow_unicode.

## Tests
- `rm -rf docs/_build; uv run ruff check . --fix --show-fixes; uv run ruff format .; uv run mypy .; uv run py.test --reruns 0 -vvv; just build-docs;`