### PR TITLE
Require Django 5.2+, support 6.1, and fix both CI matrix axes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,23 @@ jobs:
         if: ${{ matrix.django-extensions != '' }}
         run: uv pip install 'django-extensions${{ matrix.django-extensions }}'
 
-      - name: Print python versions
+      - name: Print versions
+        env:
+          DJANGO_VERSION: ${{ matrix.django-version }}
         run: |
           python -V
           uv run python -V
+          uv run python - <<'PY'
+          import os
+
+          import django
+
+          want = os.environ["DJANGO_VERSION"]
+          got = django.get_version()
+          print("Django", got)
+          if got.split(".")[:2] != want.split("."):
+              raise SystemExit(f"expected Django {want}.x, got {got}")
+          PY
 
       - name: Lint with ruff check
         run: uv run ruff check .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,13 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.14']
-        django-version: ['4.2', '5.1', '5.2']
+        django-version: ['4.2', '5.1', '5.2', '6.0', '6.1']
+        exclude:
+          # Django 6.x requires Python 3.12+
+          - python-version: '3.10'
+            django-version: '6.0'
+          - python-version: '3.10'
+            django-version: '6.1'
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Install django @ ${{ matrix.django-version }}
-        run: uv pip install DJANGO~=${{ matrix.django-version }}
+        run: uv pip install "DJANGO~=${{ matrix.django-version }}.0"
 
       - name: Install django-extensions @ ${{ matrix.django-extensions }}, if exists
         if: ${{ matrix.django-extensions != '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,11 @@ jobs:
     # `uv run` re-syncs the environment from uv.lock before every command,
     # which reinstalls the locked django over the one the matrix leg pinned.
     # The one sync stays explicit, in "Install dependencies".
+    # `uv python install` only makes an interpreter available; .python-version
+    # still selects it, so UV_PYTHON is what binds the leg to its python.
     env:
       UV_NO_SYNC: '1'
+      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       matrix:
         python-version: ['3.10', '3.14']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,11 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
+    # `uv run` re-syncs the environment from uv.lock before every command,
+    # which reinstalls the locked django over the one the matrix leg pinned.
+    # The one sync stays explicit, in "Install dependencies".
+    env:
+      UV_NO_SYNC: '1'
     strategy:
       matrix:
         python-version: ['3.10', '3.14']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,20 +48,23 @@ jobs:
 
       - name: Print versions
         env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
           DJANGO_VERSION: ${{ matrix.django-version }}
         run: |
-          python -V
-          uv run python -V
           uv run python - <<'PY'
           import os
+          import sys
 
           import django
 
-          want = os.environ["DJANGO_VERSION"]
-          got = django.get_version()
-          print("Django", got)
-          if got.split(".")[:2] != want.split("."):
-              raise SystemExit(f"expected Django {want}.x, got {got}")
+          checks = (
+              ("Python", os.environ["PYTHON_VERSION"], "%d.%d" % sys.version_info[:2]),
+              ("Django", os.environ["DJANGO_VERSION"], django.get_version()),
+          )
+          for name, want, got in checks:
+              print(name, got)
+              if got.split(".")[:2] != want.split("."):
+                  raise SystemExit(f"expected {name} {want}.x, got {got}")
           PY
 
       - name: Lint with ruff check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.14']
-        django-version: ['4.2', '5.1', '5.2', '6.0', '6.1']
+        django-version: ['5.2', '6.0', '6.1']
         exclude:
           # Django 6.x requires Python 3.12+
           - python-version: '3.10'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,14 @@ Key features:
 - Plug-in pipeline of slugify processors defined via `SLUGIFY_PROCESSORS` in Django settings
 - Drop-in replacement for Django's `slugify` utility and template filter
 - Keeps default Django behavior when no processors are configured
-- Compatible with Django 4.2–6.1; tested on Python 3.10+
+- Compatible with Django 5.2–6.1; tested on Python 3.10+
 - Sphinx docs and doctest-friendly examples powered by gp-libs extensions
 
 ## Development Environment
 
 This project uses:
 - Python 3.10+
-- Django 4.2+ (tested through 6.1; 6.x requires Python 3.12+)
+- Django 5.2+ (tested through 6.1; 6.x requires Python 3.12+)
 - [uv](https://github.com/astral-sh/uv) for dependency management
 - [ruff](https://github.com/astral-sh/ruff) for linting and formatting
 - [mypy](https://github.com/python/mypy) for type checking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,14 +19,14 @@ Key features:
 - Plug-in pipeline of slugify processors defined via `SLUGIFY_PROCESSORS` in Django settings
 - Drop-in replacement for Django's `slugify` utility and template filter
 - Keeps default Django behavior when no processors are configured
-- Compatible with Django 4.2–5.2; tested on Python 3.10+
+- Compatible with Django 4.2–6.1; tested on Python 3.10+
 - Sphinx docs and doctest-friendly examples powered by gp-libs extensions
 
 ## Development Environment
 
 This project uses:
 - Python 3.10+
-- Django 4.2+ (tested through 5.2)
+- Django 4.2+ (tested through 6.1; 6.x requires Python 3.12+)
 - [uv](https://github.com/astral-sh/uv) for dependency management
 - [ruff](https://github.com/astral-sh/ruff) for linting and formatting
 - [mypy](https://github.com/python/mypy) for type checking

--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,25 @@ pages easier to scan, and local automation easier to run. It also exposes
 documentation tooling can build correct source links without reaching into
 package metadata.
 
+### Breaking changes
+
+#### Django 5.2 is the minimum supported release (#426)
+
+Minimum `django>=5.2` (was `>=4.2`). Django 4.2 LTS reached end of life on
+2026-04-07 and Django 5.1 on 2025-12-03, so neither receives security patches.
+Django 5.2 LTS is supported upstream until 2028-04-30.
+
+Projects pinned below 5.2 need to move Django forward before taking this
+release:
+
+```console
+$ uv add 'django>=5.2'
+```
+
+Nothing else changes for them. {func}`~django_slugify_processor.text.slugify`
+and its template filter behave the same, `SLUGIFY_PROCESSORS` is untouched, and
+the package's own Python floor stays at 3.10.
+
 ### What's new
 
 #### Django 6.1 support (#426)

--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,17 @@ package metadata.
 
 ### What's new
 
+#### Django 6.1 support (#426)
+
+django-slugify-processor supports Django 6.1 and 6.0. Both are declared in the
+package's trove classifiers and covered by the test matrix.
+{func}`~django_slugify_processor.text.slugify` and
+{func}`~django_slugify_processor.templatetags.slugify_processor.slugify` needed
+no changes, so projects can upgrade without revisiting `SLUGIFY_PROCESSORS`.
+
+Django 6.x requires Python 3.12 or newer. Installations on Python 3.10 and 3.11
+continue to resolve Django 5.2 LTS; the package's own Python floor is unchanged.
+
 #### Package version metadata is available at import time
 
 {data}`django_slugify_processor.__version__` now re-exports the version from
@@ -117,6 +128,12 @@ and invalidates targeted [CloudFront](https://aws.amazon.com/cloudfront/) paths
 after upload. That removes long-lived AWS access keys from the publishing path
 while keeping the existing S3 and CDN deployment model.
 
+#### Django documentation links follow the current release (#426)
+
+Prose links and API cross-references into Django's documentation now resolve
+against its current stable release instead of a pinned 4.2, so readers land on
+the documentation for the Django they are running.
+
 ### Development
 
 #### Task runner replaces the project Makefiles (#411)
@@ -167,6 +184,12 @@ Linting runs on ruff's curated default rule set, with this project's own linters
 layered on top through `extend-select`. Pylint, flake8-pyi, and flake8-bandit
 checks now apply; the Sphinx config carries a scoped per-file ignore for the
 `exec` it uses to read the package's metadata module.
+
+#### The test matrix runs the versions it names (#426)
+
+Each leg of the test matrix now runs the Python and Django pair it is labelled
+with, and fails when it does not. Both axes were previously overridden before
+the suite ran, so the matrix reported broader coverage than it actually had.
 
 ## django-slugify-processor 1.10.0 (2025-11-01)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,8 +37,8 @@ conf = merge_sphinx_config(
     intersphinx_mapping={
         "py": ("https://docs.python.org", None),
         "django": (
-            "https://docs.djangoproject.com/en/4.2/",
-            "https://docs.djangoproject.com/en/4.2/_objects/",
+            "https://docs.djangoproject.com/en/stable/",
+            "https://docs.djangoproject.com/en/stable/objects.inv",
         ),
     },
     linkcode_resolve=make_linkcode_resolve(

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ slug:
 ```
 
 Register the processor's import string in your
-[Django settings](https://docs.djangoproject.com/en/4.2/topics/settings/):
+[Django settings](https://docs.djangoproject.com/en/stable/topics/settings/):
 
 ```python
 SLUGIFY_PROCESSORS = [

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -189,7 +189,7 @@ $ uv add \
     'django-slugify-processor @ git+https://github.com/tony/django-slugify-processor.git'
 ```
 
-[django settings]: https://docs.djangoproject.com/en/4.2/topics/settings/
+[django settings]: https://docs.djangoproject.com/en/stable/topics/settings/
 [pip]: https://pip.pypa.io/en/stable/
 [pypi]: https://pypi.org/project/django-slugify-processor/
 [uv]: https://docs.astral.sh/uv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ classifiers = [
   'Development Status :: 5 - Production/Stable',
   'Environment :: Web Environment',
   'Framework :: Django',
-  'Framework :: Django :: 4.2',
-  'Framework :: Django :: 5.1',
   'Framework :: Django :: 5.2',
   'Framework :: Django :: 6.0',
   'Framework :: Django :: 6.1',
@@ -41,7 +39,7 @@ include = [
 keywords = ["django", "slug", "text"]
 homepage = "https://django-slugify-processor.git-pull.com"
 dependencies = [
-  "django>=4.2"
+  "django>=5.2"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
 
-# Django is the sole runtime dependency; new releases must resolve on day one.
+# Cooldown would hold the lock on a known-vulnerable django after each security release.
 django = false
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
   'Framework :: Django :: 4.2',
   'Framework :: Django :: 5.1',
   'Framework :: Django :: 5.2',
+  'Framework :: Django :: 6.0',
+  'Framework :: Django :: 6.1',
   'Intended Audience :: Developers',
   'License :: OSI Approved :: MIT License',
   'Operating System :: OS Independent',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,9 @@ sphinx-gp-theme = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
 
+# Django is the sole runtime dependency; new releases must resolve on day one.
+django = false
+
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 strict = true

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pathlib
 import subprocess
+import sys
 import typing as t
 
 import pytest
@@ -54,6 +55,10 @@ def test_library_install_docs_do_not_recommend_tool_installers(
         assert forbidden_command not in text
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="docs extensions need sphinx>=8.2, which requires python 3.11+",
+)
 def test_sphinx_doctest_builder_runs() -> None:
     """Assert docs/ doctest examples run without requiring external just."""
     completed = subprocess.run(

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=4.2" },
+    { name = "django", specifier = ">=5.2" },
     { name = "django-extensions", marker = "extra == 'django-extensions'" },
 ]
 provides-extras = ["django-extensions"]

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ sphinx-gp-llms = false
 sphinx-autodoc-argparse = false
 sphinx-ux-autodoc-layout = false
 sphinx-ux-badges = false
+django = false
 gp-libs = false
 sphinx-autodoc-docutils = false
 gp-furo-theme = false
@@ -376,7 +377,7 @@ toml = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version == '3.11.*'",
@@ -387,14 +388,14 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]
 name = "django"
-version = "6.0.7"
+version = "6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -405,9 +406,9 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
 ]
 
 [[package]]
@@ -415,8 +416,8 @@ name = "django-extensions"
 version = "4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b3/ed0f54ed706ec0b54fd251cc0364a249c6cd6c6ec97f04dc34be5e929eac/django_extensions-4.1.tar.gz", hash = "sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb", size = 283078, upload-time = "2025-04-11T01:15:39.617Z" }
 wheels = [
@@ -428,8 +429,8 @@ name = "django-slugify-processor"
 version = "1.10.0"
 source = { editable = "." }
 dependencies = [
-    { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.optional-dependencies]
@@ -541,8 +542,8 @@ name = "django-stubs"
 version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "django-stubs-ext" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-pyyaml" },
@@ -558,8 +559,8 @@ name = "django-stubs-ext"
 version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/50/917f7224ea470e89cdcdc93d3dfe75b8391adf976cf12f2ecdb5f5d122be/django_stubs_ext-6.0.7.tar.gz", hash = "sha256:c3172c5126614fd2a44d0196b313b44c21f717cb09477ba52b447d41f4ce613e", size = 6665, upload-time = "2026-07-14T10:07:56.933Z" }


### PR DESCRIPTION
## Breaking change

**Minimum `django>=5.2` (was `>=4.2`).** Django 4.2 LTS reached end of life on 2026-04-07 and Django 5.1 on 2025-12-03 ([endoflife.date/django](https://endoflife.date/django)); neither receives security patches. Django 5.2 LTS is supported upstream until 2028-04-30.

Projects pinned below 5.2 need to move Django forward before taking this release:

```console
$ uv add 'django>=5.2'
```

Nothing else changes for them: `slugify` and the template filter behave the same, `SLUGIFY_PROCESSORS` is untouched, and the package's own Python floor stays at 3.10.

## Summary

- **Add** Django 6.1 support: matrix legs for 6.0 and 6.1, both declared in the trove classifiers, with `uv.lock` resolving 6.1 on Python 3.12+. No source changes were needed — `slugify` and the template filter pass against both unmodified.
- **Drop** end-of-life Django 4.2 and 5.1, raising the floor to the current 5.2 LTS (see the breaking change above).
- **Fix** matrix legs installing `django~=X.Y`, a specifier that floats across an entire major series. The `5.1` leg resolved 5.2.17, duplicating the `5.2` leg and leaving 5.1 with no coverage.
- **Fix** `uv run` re-syncing the environment from `uv.lock` before every step, which uninstalled the Django the leg had just installed.
- **Fix** the Python axis, which was inert for a related reason: `uv python install` makes an interpreter available without selecting it, so `.python-version` kept every leg on 3.14 and the Django 6.x exclusions for 3.10 guarded nothing. Between the two axes, no leg ran the pair it named.
- **Guard** both axes so the regression cannot return silently: a leg now fails when the Python or the Django it is running is not the one it asked for.
- **Exempt** `django` from the 3-day `uv` release cooldown so security releases reach the lockfile, and therefore CI, the day they ship.

## What each leg actually runs

Both matrix axes were inert before this branch; taken from the run logs:

| Leg | Ran before | Runs now |
|---|---|---|
| py3.10 × 5.2 | py3.14 + django 5.2.16 | py3.10.20 + django 5.2.17 |
| py3.14 × 5.2 | py3.14 + django 6.0.7 | py3.14.7 + django 5.2.17 |
| py3.14 × 6.0 | — | py3.14.7 + django 6.0.8 |
| py3.14 × 6.1 | — | py3.14.7 + django 6.1 |

The 4.2 and 5.1 legs are gone with the floor bump.

## Changes

**`.github/workflows/tests.yml`** — adds `6.0` and `6.1` to the `django-version` matrix and excludes both from the Python 3.10 leg; appends the patch component to the install constraint; sets `UV_NO_SYNC` and `UV_PYTHON` job-wide; turns the version step into a guard.

**`pyproject.toml`** — raises the dependency floor to `django>=5.2`; drops the `4.2` and `5.1` classifiers and adds `6.0` and `6.1`; adds `django = false` to `[tool.uv.exclude-newer-package]`.

**`uv.lock`** — django 6.0.7 to 6.1 for `python >= 3.12`, and 5.2.16 to 5.2.17 for `python < 3.12`.

**`tests/test_docs_examples.py`** — gates the Sphinx doctest build on Python 3.11+.

**`docs/conf.py`, `docs/index.md`, `docs/quickstart.md`** — Django prose links and the intersphinx inventory move from `/en/4.2/` to `/en/stable/`.

**`AGENTS.md`, `CHANGES`** — compatibility range reads Django 5.2–6.1, plus changelog deliverables including the breaking change.

## Design decisions

**`~=X.Y.0` rather than `==X.Y.*`** — `~=6.0.0` means `>=6.0.0, ==6.0.*`, so a leg tracks its series' latest security patch without crossing into the next feature release. Matrix values stay as `6.0` so job names remain readable.

**`UV_NO_SYNC` and `UV_PYTHON` on the job rather than per step** — one declaration covers every `uv run` in the job and can't be forgotten when a step is added later. The explicit `uv sync --all-extras --dev` step is unaffected.

**The guard covers both axes and compares two version segments** — `django.get_version()` returns `6.1` for a `.0` release, not `6.1.0`, so a `startswith("6.1.")` check would fail the leg it exists to protect. Guarding Python as well as Django is what would have surfaced the interpreter bug on its own rather than by reading run logs. Matrix values reach the script through `env` rather than inline interpolation.

**`django = false` rather than a dated exemption** — uv resolves the lock CI runs against, so a cooldown holds it on a known-vulnerable Django for three days after each security release. A dated exemption would bound Django's own `exclude-newer` and block those releases until someone edited the value: the opposite of the intent.

**The Sphinx doctest test is gated, not fixed** — the docs extensions need `BuildEnvironment.current_document`, added in Sphinx 8.2, and Sphinx 8.2 requires Python 3.11. On 3.10 the resolver falls back to 8.1.3 and the build fails before reading a page. This is pre-existing and unrelated to Django; binding the Python axis is what made it visible. Raising the project's Python floor is a separate decision.

**Python floor stays at `>=3.10`** — Django 6.x requires 3.12+, but raising it would drop users correctly served by Django 5.2 LTS, which itself supports 3.10. uv's universal resolution splits the lock with environment markers, so the Python 3.10 leg resolves to 5.2.17 on its own.

**Django 6.0 declared alongside 6.1** — the lockfile has resolved 6.0 on Python 3.12+ since December while the classifiers stopped at 5.2. Shipping `Framework :: Django :: 6.1` while omitting 6.0 would have implied 6.0 was unsupported.

**5.2 as the floor rather than 5.1** — 5.1 reached end of life on 2025-12-03, so a `>=5.1` floor would still have admitted an unsupported release. 5.2 is the current LTS and the oldest Django still receiving security patches.

## Verification

`~=X.Y` floats across the major series:

```console
$ uv pip install --dry-run 'django~=5.1'
```

Resolves `django==5.2.17`. With the trailing `.0` it resolves `django==5.1.15`. And `uv run` reverts a leg's install unless `UV_NO_SYNC` is set:

```console
$ uv pip install 'django~=5.1.0' && uv run python -c "import django; print(django.get_version())"
```

Prints the locked version rather than 5.1.15; re-run with `UV_NO_SYNC=1` and it prints 5.1.15. The Python axis fails the same way — with `.python-version` pinned to 3.14, `uv python install 3.10` leaves `uv run python -V` reporting 3.14:

```console
$ UV_PYTHON=3.10 uv run python -V
```

Reports 3.10 where the bare command reports 3.14.

## Test plan

- [x] Full suite passes on Python 3.14 against each matrix Django: 5.2.17, 6.0.8, and 6.1
- [x] Full suite passes on a real Python 3.10 against 5.2.17
- [x] Sphinx doctest test runs on 3.14 and skips on 3.10
- [x] `uv run ruff check .` and `uv run ruff format . --check` clean
- [x] `uv run mypy` clean
- [x] `cd docs && just html` — Sphinx build succeeds; Django xrefs resolve to the 6.1 inventory
- [x] Guard exits non-zero when either the running Python or the installed Django does not match the leg
- [x] CI green across all four legs, with the run logs confirming each leg's interpreter and Django

## Related

Sibling PRs applying overlapping fixes: tony/django-docutils#469, tony/django-search-query#8.
